### PR TITLE
feat!: Add Neo4j 5.0+ elementId support and release v1.0.0

### DIFF
--- a/packages/dart_bolt/CHANGELOG.md
+++ b/packages/dart_bolt/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0
+
+### Stable Release
+
+- First stable release of dart_bolt
+
 ## 0.2.0
 
 - Updated Dart SDK requirement to ^3.8.0

--- a/packages/dart_bolt/lib/src/connection/bolt_protocol.dart
+++ b/packages/dart_bolt/lib/src/connection/bolt_protocol.dart
@@ -69,12 +69,10 @@ class BoltProtocol {
 
     _agreedVersion = await versionCompleter.future.timeout(
       const Duration(seconds: 10),
-      onTimeout:
-          () =>
-              throw ConnectionTimeoutException(
-                'Handshake timeout: server did not respond to version negotiation',
-                const Duration(seconds: 10),
-              ),
+      onTimeout: () => throw ConnectionTimeoutException(
+        'Handshake timeout: server did not respond to version negotiation',
+        const Duration(seconds: 10),
+      ),
     );
 
     if (_agreedVersion == 0) {

--- a/packages/dart_bolt/lib/src/structures/relationship.dart
+++ b/packages/dart_bolt/lib/src/structures/relationship.dart
@@ -24,15 +24,15 @@ class BoltRelationship extends PsStructure {
          0x52, // 'R'
          elementId != null
              ? [
-               id,
-               startNodeId,
-               endNodeId,
-               type,
-               properties,
-               elementId,
-               startNodeElementId!,
-               endNodeElementId!,
-             ]
+                 id,
+                 startNodeId,
+                 endNodeId,
+                 type,
+                 properties,
+                 elementId,
+                 startNodeElementId!,
+                 endNodeElementId!,
+               ]
              : [id, startNodeId, endNodeId, type, properties],
        );
 

--- a/packages/dart_bolt/pubspec.yaml
+++ b/packages/dart_bolt/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  dart_packstream: ^0.2.0
+  dart_packstream: ^1.0.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/dart_bolt/pubspec.yaml
+++ b/packages/dart_bolt/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_bolt
 description: A Dart library for Bolt protocol implementation.
-version: 0.2.0
+version: 1.0.0
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_bolt
 

--- a/packages/dart_neo4j/CHANGELOG.md
+++ b/packages/dart_neo4j/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 1.0.0
+
+### BREAKING CHANGES
+
+- **Deprecated `id` Property**: The numeric `id` property on `Node`, `Relationship`, and `UnboundRelationship` is now deprecated in favor of `elementId`
+  - Use `elementId` (nullable) or `elementIdOrThrow` (non-nullable) for Neo4j 5.0+ compatibility
+  - The old `id` property will continue to work but will emit deprecation warnings
+  - See [Neo4j documentation](https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id) for migration guidance
+
+### New Features
+
+- **Neo4j 5.0+ Element ID Support**: Added full support for string-based element IDs
+  - `Node.elementId`: Returns the element ID as a nullable String
+  - `Node.elementIdOrThrow`: Returns the element ID or throws if not available
+  - `Relationship.elementId`: Returns the relationship element ID as a nullable String
+  - `Relationship.elementIdOrThrow`: Returns the relationship element ID or throws if not available
+  - `UnboundRelationship.elementId`: Returns the relationship element ID as a nullable String
+  - `UnboundRelationship.elementIdOrThrow`: Returns the relationship element ID or throws if not available
+- **Improved Equality Comparisons**: Node and Relationship equality now prefers `elementId` when available, falling back to numeric `id` for backward compatibility
+- **Enhanced toString**: Node, Relationship, and UnboundRelationship now include `elementId` in their string representations when available
+
+### Improvements
+
+- **Future-Proof Design**: Smooth migration path from numeric IDs to element IDs
+- **Backward Compatibility**: Existing code using numeric IDs continues to work with deprecation warnings
+- **Comprehensive Test Coverage**: Added extensive tests for element ID functionality
+
 ## 0.2.0
 
 - Updated Dart SDK requirement to ^3.8.0

--- a/packages/dart_neo4j/lib/src/session/transaction_impl.dart
+++ b/packages/dart_neo4j/lib/src/session/transaction_impl.dart
@@ -90,9 +90,8 @@ abstract class TransactionImpl implements Transaction {
       await _pooledConnection.connection.rollbackTransaction();
       _state = TransactionState.rolledBack;
     } catch (e) {
-      _state =
-          TransactionState
-              .rolledBack; // Still mark as rolled back even if message fails
+      _state = TransactionState
+          .rolledBack; // Still mark as rolled back even if message fails
       throw DatabaseException('Failed to rollback transaction: $e', null, e);
     } finally {
       await _cleanup();

--- a/packages/dart_neo4j/lib/src/types/neo4j_types.dart
+++ b/packages/dart_neo4j/lib/src/types/neo4j_types.dart
@@ -14,7 +14,30 @@ class Node {
   }
 
   /// The unique identifier of the node.
+  ///
+  /// **Deprecated:** This property uses the legacy numeric ID which is deprecated in Neo4j 5.0+.
+  /// Use [elementId] or [elementIdOrThrow] instead.
+  ///
+  /// See: https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id
+  @Deprecated(
+    'Use elementId or elementIdOrThrow instead. '
+    'The id() function is deprecated in Neo4j 5.0+. '
+    'See https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id',
+  )
   int get id => _boltNode.id.dartValue;
+
+  /// The element ID of the node.
+  String? get elementId => _boltNode.elementId?.dartValue;
+
+  /// The element ID of the node.
+  ///
+  /// Throws [StateError] if the node has no element ID.
+  ///
+  /// Requires Neo4j 5.0+ to be used as `elementId` is not supported in earlier versions.
+  String get elementIdOrThrow => switch (_boltNode.elementId?.dartValue) {
+    String value => value,
+    null => throw StateError('Node has no element ID'),
+  };
 
   /// The labels assigned to the node.
   List<String> get labels =>
@@ -77,17 +100,37 @@ class Node {
 
   @override
   String toString() {
-    return 'Node{id: $id, labels: $labels, properties: $properties}';
+    final elementIdStr = elementId != null ? ', elementId: $elementId' : '';
+    // ignore: deprecated_member_use_from_same_package
+    return 'Node{id: $id$elementIdStr, labels: $labels, properties: $properties}';
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is Node && other.id == id;
+    if (other is! Node) return false;
+
+    // Prefer elementId for comparison when available on both nodes
+    if (elementId != null && other.elementId != null) {
+      return elementId == other.elementId;
+    }
+
+    // Fall back to id comparison for backward compatibility
+    // ignore: deprecated_member_use_from_same_package
+    return id == other.id;
   }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode {
+    // Prefer elementId for hash code when available
+    if (elementId != null) {
+      return elementId.hashCode;
+    }
+
+    // Fall back to id for backward compatibility
+    // ignore: deprecated_member_use_from_same_package
+    return id.hashCode;
+  }
 }
 
 /// A relationship in a Neo4j graph.
@@ -103,7 +146,31 @@ class Relationship {
   }
 
   /// The unique identifier of the relationship.
+  ///
+  /// **Deprecated:** This property uses the legacy numeric ID which is deprecated in Neo4j 5.0+.
+  /// Use [elementId] or [elementIdOrThrow] instead.
+  ///
+  /// See: https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id
+  @Deprecated(
+    'Use elementId or elementIdOrThrow instead. '
+    'The id() function is deprecated in Neo4j 5.0+. '
+    'See https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id',
+  )
   int get id => _boltRelationship.id.dartValue;
+
+  /// The element ID of the relationship.
+  String? get elementId => _boltRelationship.elementId?.dartValue;
+
+  /// The element ID of the relationship.
+  ///
+  /// Throws [StateError] if the relationship has no element ID.
+  ///
+  /// Requires Neo4j 5.0+ to be used as `elementId` is not supported in earlier versions.
+  String get elementIdOrThrow =>
+      switch (_boltRelationship.elementId?.dartValue) {
+        String value => value,
+        null => throw StateError('Relationship has no element ID'),
+      };
 
   /// The type of the relationship.
   String get type => _boltRelationship.type.dartValue;
@@ -166,17 +233,37 @@ class Relationship {
 
   @override
   String toString() {
-    return 'Relationship{id: $id, type: $type, startNodeId: $startNodeId, endNodeId: $endNodeId, properties: $properties}';
+    final elementIdStr = elementId != null ? ', elementId: $elementId' : '';
+    // ignore: deprecated_member_use_from_same_package
+    return 'Relationship{id: $id$elementIdStr, type: $type, startNodeId: $startNodeId, endNodeId: $endNodeId, properties: $properties}';
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is Relationship && other.id == id;
+    if (other is! Relationship) return false;
+
+    // Prefer elementId for comparison when available on both relationships
+    if (elementId != null && other.elementId != null) {
+      return elementId == other.elementId;
+    }
+
+    // Fall back to id comparison for backward compatibility
+    // ignore: deprecated_member_use_from_same_package
+    return id == other.id;
   }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode {
+    // Prefer elementId for hash code when available
+    if (elementId != null) {
+      return elementId.hashCode;
+    }
+
+    // Fall back to id for backward compatibility
+    // ignore: deprecated_member_use_from_same_package
+    return id.hashCode;
+  }
 }
 
 /// An unbound relationship (without start/end node IDs).
@@ -194,7 +281,29 @@ class UnboundRelationship {
   }
 
   /// The unique identifier of the relationship.
+  ///
+  /// **Deprecated:** This property uses the legacy numeric ID which is deprecated in Neo4j 5.0+.
+  ///
+  /// See: https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id
+  @Deprecated(
+    'The id() function is deprecated in Neo4j 5.0+. '
+    'See https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id',
+  )
   int get id => _boltUnboundRelationship.id.dartValue;
+
+  /// The element ID of the relationship.
+  String? get elementId => _boltUnboundRelationship.elementId?.dartValue;
+
+  /// The element ID of the relationship.
+  ///
+  /// Throws [StateError] if the relationship has no element ID.
+  ///
+  /// Requires Neo4j 5.0+ to be used as `elementId` is not supported in earlier versions.
+  String get elementIdOrThrow =>
+      switch (_boltUnboundRelationship.elementId?.dartValue) {
+        String value => value,
+        null => throw StateError('UnboundRelationship has no element ID'),
+      };
 
   /// The type of the relationship.
   String get type => _boltUnboundRelationship.type.dartValue;
@@ -252,17 +361,37 @@ class UnboundRelationship {
 
   @override
   String toString() {
-    return 'UnboundRelationship{id: $id, type: $type, properties: $properties}';
+    final elementIdStr = elementId != null ? ', elementId: $elementId' : '';
+    // ignore: deprecated_member_use_from_same_package
+    return 'UnboundRelationship{id: $id$elementIdStr, type: $type, properties: $properties}';
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    return other is UnboundRelationship && other.id == id;
+    if (other is! UnboundRelationship) return false;
+
+    // Prefer elementId for comparison when available on both relationships
+    if (elementId != null && other.elementId != null) {
+      return elementId == other.elementId;
+    }
+
+    // Fall back to id comparison for backward compatibility
+    // ignore: deprecated_member_use_from_same_package
+    return id == other.id;
   }
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode {
+    // Prefer elementId for hash code when available
+    if (elementId != null) {
+      return elementId.hashCode;
+    }
+
+    // Fall back to id for backward compatibility
+    // ignore: deprecated_member_use_from_same_package
+    return id.hashCode;
+  }
 }
 
 /// A path in a Neo4j graph, consisting of nodes and relationships.
@@ -273,18 +402,15 @@ class Path {
 
   /// Creates a new path from a Bolt path.
   Path._(this._boltPath)
-    : _nodes =
-          _boltPath.nodes
-              .map((node) => Node.fromBolt(node as BoltNode))
-              .toList(),
-      _relationships =
-          _boltPath.relationships
-              .map(
-                (rel) => UnboundRelationship.fromBolt(
-                  rel as BoltUnboundRelationship,
-                ),
-              )
-              .toList();
+    : _nodes = _boltPath.nodes
+          .map((node) => Node.fromBolt(node as BoltNode))
+          .toList(),
+      _relationships = _boltPath.relationships
+          .map(
+            (rel) =>
+                UnboundRelationship.fromBolt(rel as BoltUnboundRelationship),
+          )
+          .toList();
 
   /// Creates a path from a Bolt path.
   factory Path.fromBolt(BoltPath boltPath) {

--- a/packages/dart_neo4j/pubspec.yaml
+++ b/packages/dart_neo4j/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  dart_bolt: ^0.2.0
+  dart_bolt: ^1.0.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/dart_neo4j/pubspec.yaml
+++ b/packages/dart_neo4j/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j
 description: A comprehensive Neo4j driver for Dart supporting both bolt:// and neo4j:// URI schemes with type-safe result access.
-version: 0.2.0
+version: 1.0.0
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j
 

--- a/packages/dart_neo4j/test/helpers/test_data.dart
+++ b/packages/dart_neo4j/test/helpers/test_data.dart
@@ -61,10 +61,9 @@ class TestData {
     // Create relationships in batches using separate queries
     const relBatchSize = 50;
     for (int i = 0; i < relationshipCount; i += relBatchSize) {
-      final endIndex =
-          (i + relBatchSize < relationshipCount)
-              ? i + relBatchSize
-              : relationshipCount;
+      final endIndex = (i + relBatchSize < relationshipCount)
+          ? i + relBatchSize
+          : relationshipCount;
 
       for (int j = i; j < endIndex; j++) {
         final from = j % nodeCount;

--- a/packages/dart_neo4j/test/integration/routing/routing_test.dart
+++ b/packages/dart_neo4j/test/integration/routing/routing_test.dart
@@ -70,11 +70,10 @@ void main() {
           expect(records.length, greaterThan(0));
 
           // Should have at least core members
-          final coreMembers =
-              records.where((record) {
-                final role = record['role'] as String?;
-                return role == 'LEADER' || role == 'FOLLOWER';
-              }).toList();
+          final coreMembers = records.where((record) {
+            final role = record['role'] as String?;
+            return role == 'LEADER' || role == 'FOLLOWER';
+          }).toList();
 
           expect(coreMembers.length, greaterThan(0));
         } catch (e) {
@@ -426,10 +425,9 @@ void main() {
             );
           });
 
-          lastBookmark =
-              writeSession.lastBookmarks.isNotEmpty
-                  ? writeSession.lastBookmarks.last
-                  : null;
+          lastBookmark = writeSession.lastBookmarks.isNotEmpty
+              ? writeSession.lastBookmarks.last
+              : null;
         } finally {
           await writeSession.close();
         }

--- a/packages/dart_neo4j/test/unit/result/record_test.dart
+++ b/packages/dart_neo4j/test/unit/result/record_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:dart_bolt/dart_bolt.dart';
 import 'package:dart_neo4j/src/exceptions/type_exception.dart';
 import 'package:dart_neo4j/src/result/record.dart';

--- a/packages/dart_neo4j/test/unit/types/neo4j_types_test.dart
+++ b/packages/dart_neo4j/test/unit/types/neo4j_types_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:dart_bolt/dart_bolt.dart';
 import 'package:dart_neo4j/src/exceptions/type_exception.dart';
 import 'package:dart_neo4j/src/types/neo4j_types.dart';
@@ -109,6 +111,71 @@ void main() {
 
         expect(node, isNot(equals(node2)));
       });
+
+      group('elementId', () {
+        test('should return null when node has no element ID (pre-5.0)', () {
+          final boltNodeWithoutElementId = BoltNode(
+            PsInt.compact(123),
+            PsList([PsString('Person')]),
+            PsDictionary({PsString('name'): PsString('John')}),
+          );
+          final node = Node.fromBolt(boltNodeWithoutElementId);
+
+          expect(node.elementId, isNull);
+        });
+
+        test('should return element ID when present (5.0+)', () {
+          final boltNodeWithElementId = BoltNode(
+            PsInt.compact(123),
+            PsList([PsString('Person')]),
+            PsDictionary({PsString('name'): PsString('John')}),
+            elementId: PsString('4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:123'),
+          );
+          final node = Node.fromBolt(boltNodeWithElementId);
+
+          expect(
+            node.elementId,
+            equals('4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:123'),
+          );
+        });
+      });
+
+      group('elementIdOrThrow', () {
+        test('should throw StateError when node has no element ID', () {
+          final boltNodeWithoutElementId = BoltNode(
+            PsInt.compact(123),
+            PsList([PsString('Person')]),
+            PsDictionary({PsString('name'): PsString('John')}),
+          );
+          final node = Node.fromBolt(boltNodeWithoutElementId);
+
+          expect(
+            () => node.elementIdOrThrow,
+            throwsA(
+              isA<StateError>().having(
+                (e) => e.message,
+                'message',
+                equals('Node has no element ID'),
+              ),
+            ),
+          );
+        });
+
+        test('should return element ID when present (5.0+)', () {
+          final boltNodeWithElementId = BoltNode(
+            PsInt.compact(123),
+            PsList([PsString('Person')]),
+            PsDictionary({PsString('name'): PsString('John')}),
+            elementId: PsString('4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:123'),
+          );
+          final node = Node.fromBolt(boltNodeWithElementId);
+
+          expect(
+            node.elementIdOrThrow,
+            equals('4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:123'),
+          );
+        });
+      });
     });
 
     group('Relationship', () {
@@ -191,6 +258,94 @@ void main() {
         expect(relationship, equals(rel2));
         expect(relationship.hashCode, equals(rel2.hashCode));
       });
+
+      group('elementId', () {
+        test(
+          'should return null when relationship has no element ID (pre-5.0)',
+          () {
+            final boltRelWithoutElementId = BoltRelationship(
+              PsInt.compact(456),
+              PsInt.compact(123),
+              PsInt.compact(789),
+              PsString('KNOWS'),
+              PsDictionary({PsString('since'): PsInt.compact(2020)}),
+            );
+            final rel = Relationship.fromBolt(boltRelWithoutElementId);
+
+            expect(rel.elementId, isNull);
+          },
+        );
+
+        test('should return element ID when present (5.0+)', () {
+          final boltRelWithElementId = BoltRelationship(
+            PsInt.compact(456),
+            PsInt.compact(123),
+            PsInt.compact(789),
+            PsString('KNOWS'),
+            PsDictionary({PsString('since'): PsInt.compact(2020)}),
+            elementId: PsString('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+            startNodeElementId: PsString(
+              '4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:123',
+            ),
+            endNodeElementId: PsString(
+              '4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:789',
+            ),
+          );
+          final rel = Relationship.fromBolt(boltRelWithElementId);
+
+          expect(
+            rel.elementId,
+            equals('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+          );
+        });
+      });
+
+      group('elementIdOrThrow', () {
+        test('should throw StateError when relationship has no element ID', () {
+          final boltRelWithoutElementId = BoltRelationship(
+            PsInt.compact(456),
+            PsInt.compact(123),
+            PsInt.compact(789),
+            PsString('KNOWS'),
+            PsDictionary({PsString('since'): PsInt.compact(2020)}),
+          );
+          final rel = Relationship.fromBolt(boltRelWithoutElementId);
+
+          expect(
+            () => rel.elementIdOrThrow,
+            throwsA(
+              isA<StateError>().having(
+                (e) => e.message,
+                'message',
+                equals('Relationship has no element ID'),
+              ),
+            ),
+          );
+        });
+
+        test('should return element ID when present (5.0+)', () {
+          final boltRelWithElementId = BoltRelationship(
+            PsInt.compact(456),
+            PsInt.compact(123),
+            PsInt.compact(789),
+            PsString('KNOWS'),
+            PsDictionary({PsString('since'): PsInt.compact(2020)}),
+            elementId: PsString('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+            startNodeElementId: PsString(
+              '4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:123',
+            ),
+            endNodeElementId: PsString(
+              '4:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:789',
+            ),
+          );
+          final rel = Relationship.fromBolt(boltRelWithElementId);
+
+          expect(
+            rel.elementIdOrThrow,
+            equals('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+          );
+        });
+      });
     });
 
     group('UnboundRelationship', () {
@@ -234,6 +389,78 @@ void main() {
         expect(str, contains('UnboundRelationship'));
         expect(str, contains('456'));
         expect(str, contains('KNOWS'));
+      });
+
+      group('elementId', () {
+        test(
+          'should return null when relationship has no element ID (pre-5.0)',
+          () {
+            final boltUnboundRelWithoutElementId = BoltUnboundRelationship(
+              PsInt.compact(456),
+              PsString('KNOWS'),
+              PsDictionary({PsString('since'): PsInt.compact(2020)}),
+            );
+            final rel = UnboundRelationship.fromBolt(
+              boltUnboundRelWithoutElementId,
+            );
+
+            expect(rel.elementId, isNull);
+          },
+        );
+
+        test('should return element ID when present (5.0+)', () {
+          final boltUnboundRelWithElementId = BoltUnboundRelationship(
+            PsInt.compact(456),
+            PsString('KNOWS'),
+            PsDictionary({PsString('since'): PsInt.compact(2020)}),
+            elementId: PsString('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+          );
+          final rel = UnboundRelationship.fromBolt(boltUnboundRelWithElementId);
+
+          expect(
+            rel.elementId,
+            equals('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+          );
+        });
+      });
+
+      group('elementIdOrThrow', () {
+        test('should throw StateError when relationship has no element ID', () {
+          final boltUnboundRelWithoutElementId = BoltUnboundRelationship(
+            PsInt.compact(456),
+            PsString('KNOWS'),
+            PsDictionary({PsString('since'): PsInt.compact(2020)}),
+          );
+          final rel = UnboundRelationship.fromBolt(
+            boltUnboundRelWithoutElementId,
+          );
+
+          expect(
+            () => rel.elementIdOrThrow,
+            throwsA(
+              isA<StateError>().having(
+                (e) => e.message,
+                'message',
+                equals('UnboundRelationship has no element ID'),
+              ),
+            ),
+          );
+        });
+
+        test('should return element ID when present (5.0+)', () {
+          final boltUnboundRelWithElementId = BoltUnboundRelationship(
+            PsInt.compact(456),
+            PsString('KNOWS'),
+            PsDictionary({PsString('since'): PsInt.compact(2020)}),
+            elementId: PsString('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+          );
+          final rel = UnboundRelationship.fromBolt(boltUnboundRelWithElementId);
+
+          expect(
+            rel.elementIdOrThrow,
+            equals('5:08c55c08-9999-4242-b05b-0c0f0c0f0c0f:456'),
+          );
+        });
       });
     });
 

--- a/packages/dart_neo4j_ogm/CHANGELOG.md
+++ b/packages/dart_neo4j_ogm/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 1.0.0
+
+### BREAKING CHANGES
+
+- **Deprecated `CypherId`**: The `CypherId` type is now deprecated in favor of `CypherElementId` for Neo4j 5.0+ compatibility
+  - Use `CypherElementId` for new code targeting Neo4j 5.0+
+  - Existing code using `CypherId` will continue to work but will emit deprecation warnings
+  - Both types can coexist in the same class during migration
+
+### New Features
+
+- **CypherElementId Type**: Added type-safe `CypherElementId` sealed class for Neo4j 5.0+ string-based element IDs
+  - `CypherElementId.none()` for new nodes without element IDs
+  - `CypherElementId.value(String)` for existing nodes with Neo4j-generated element IDs
+  - Built-in JSON serialization support with `cypherElementIdToJson` and `cypherElementIdFromJson` helpers
+  - Same API surface as `CypherId` for easy migration
+  - Supports nullable element IDs with `elementIdOrNull` and `hasNoElementId` properties
+- **Dual ID Support**: Classes can now have both `CypherId` and `CypherElementId` fields for gradual migration
+- **Enhanced Type Safety**: String-based element IDs provide better type checking and Neo4j 5.0+ compatibility
+
+### Improvements
+
+- **Smooth Migration Path**: Deprecation warnings guide users to migrate at their own pace
+- **Backward Compatibility**: Existing `CypherId` code continues to work without changes
+
+### Deprecations
+
+- `CypherId` class - Use `CypherElementId` instead
+- `cypherIdToJson()` helper - Use `cypherElementIdToJson()` instead
+- `cypherIdFromJson()` helper - Use `cypherElementIdFromJson()` instead
+
 ## 0.2.0
 
 ### BREAKING CHANGES

--- a/packages/dart_neo4j_ogm/lib/dart_neo4j_ogm.dart
+++ b/packages/dart_neo4j_ogm/lib/dart_neo4j_ogm.dart
@@ -6,4 +6,5 @@ library;
 
 export 'src/annotations/cypher_node.dart';
 export 'src/annotations/cypher_property.dart';
+export 'src/types/cypher_element_id.dart';
 export 'src/types/cypher_id.dart';

--- a/packages/dart_neo4j_ogm/lib/src/types/cypher_element_id.dart
+++ b/packages/dart_neo4j_ogm/lib/src/types/cypher_element_id.dart
@@ -1,0 +1,113 @@
+/// A type-safe representation of a Cypher node element ID that can be either set or unset.
+///
+/// This sealed class allows creating nodes without an element ID (before CREATE operations)
+/// and accessing the element ID safely after the node has been persisted to Neo4j.
+///
+/// This is the recommended type for Neo4j 5.0+ which uses string-based element IDs.
+/// For legacy integer IDs, see [CypherId].
+///
+/// ## Usage with json_serializable
+///
+/// ```dart
+/// @freezed
+/// @CypherNode()
+/// class User with _$User {
+///   const factory User({
+///     @JsonKey(toJson: cypherElementIdToJson, fromJson: cypherElementIdFromJson) required CypherElementId elementId,
+///     required String name,
+///     required String email,
+///   }) = _User;
+///
+///   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+/// }
+/// ```
+sealed class CypherElementId {
+  const CypherElementId._();
+
+  /// Creates a CypherElementId with no value (for new nodes before CREATE).
+  factory CypherElementId.none() => const _CypherNoElementId();
+
+  /// Creates a CypherElementId with a specific value (for existing nodes from Neo4j).
+  factory CypherElementId.value(String elementId) =>
+      _CypherElementIdValue(elementId);
+
+  /// Gets the element ID value or throws if no element ID is set.
+  ///
+  /// Throws [StateError] if called on a node that hasn't been persisted to Neo4j yet.
+  String get elementIdOrThrow => switch (this) {
+    _CypherElementIdValue(:final elementId) => elementId,
+    _CypherNoElementId() => throw StateError(
+      'Cannot access element ID on a node that has not been persisted to Neo4j yet. '
+      'Create the node first using a CREATE query.',
+    ),
+  };
+
+  /// Gets the element ID value or returns null if no element ID is set.
+  String? get elementIdOrNull => switch (this) {
+    _CypherElementIdValue(:final elementId) => elementId,
+    _CypherNoElementId() => null,
+  };
+
+  /// Returns true if this CypherElementId has a value.
+  bool get hasElementId => switch (this) {
+    _CypherElementIdValue() => true,
+    _CypherNoElementId() => false,
+  };
+
+  /// Returns true if this CypherElementId has no value.
+  bool get hasNoElementId => !hasElementId;
+
+  /// Converts this CypherElementId to JSON representation.
+  /// Returns the element ID value or null if no element ID is set.
+  String? toJson() => elementIdOrNull;
+
+  /// Creates a CypherElementId from JSON representation.
+  /// Returns CypherElementId.none() if json is null, otherwise CypherElementId.value(json).
+  factory CypherElementId.fromJson(String? json) =>
+      json == null ? CypherElementId.none() : CypherElementId.value(json);
+}
+
+/// Internal implementation for CypherElementId with a value.
+final class _CypherElementIdValue extends CypherElementId {
+  const _CypherElementIdValue(this.elementId) : super._();
+
+  final String elementId;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _CypherElementIdValue &&
+          runtimeType == other.runtimeType &&
+          elementId == other.elementId;
+
+  @override
+  int get hashCode => elementId.hashCode;
+
+  @override
+  String toString() => 'CypherElementId.value($elementId)';
+}
+
+/// Internal implementation for CypherElementId with no value.
+final class _CypherNoElementId extends CypherElementId {
+  const _CypherNoElementId() : super._();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _CypherNoElementId && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => 0;
+
+  @override
+  String toString() => 'CypherElementId.none()';
+}
+
+/// Top-level helper function for json_serializable toJson conversion.
+/// Use with @JsonKey(toJson: cypherElementIdToJson)
+String? cypherElementIdToJson(CypherElementId elementId) => elementId.toJson();
+
+/// Top-level helper function for json_serializable fromJson conversion.
+/// Use with @JsonKey(fromJson: cypherElementIdFromJson)
+CypherElementId cypherElementIdFromJson(String? json) =>
+    CypherElementId.fromJson(json);

--- a/packages/dart_neo4j_ogm/lib/src/types/cypher_id.dart
+++ b/packages/dart_neo4j_ogm/lib/src/types/cypher_id.dart
@@ -3,6 +3,9 @@
 /// This sealed class allows creating nodes without an ID (before CREATE operations)
 /// and accessing the ID safely after the node has been persisted to Neo4j.
 ///
+/// **Deprecated:** This type uses the legacy numeric ID which is deprecated in Neo4j 5.0+.
+/// Use [CypherElementId] instead for Neo4j 5.0+ compatibility.
+///
 /// ## Usage with json_serializable
 ///
 /// ```dart
@@ -18,6 +21,11 @@
 ///   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 /// }
 /// ```
+@Deprecated(
+  'Use CypherElementId instead. '
+  'The id() function is deprecated in Neo4j 5.0+. '
+  'See https://neo4j.com/docs/cypher-manual/5/functions/scalar/#functions-id',
+)
 sealed class CypherId {
   const CypherId._();
 
@@ -64,6 +72,7 @@ sealed class CypherId {
 }
 
 /// Internal implementation for CypherId with a value.
+// ignore: deprecated_member_use_from_same_package
 final class _CypherIdValue extends CypherId {
   const _CypherIdValue(this.id) : super._();
 
@@ -84,6 +93,7 @@ final class _CypherIdValue extends CypherId {
 }
 
 /// Internal implementation for CypherId with no value.
+// ignore: deprecated_member_use_from_same_package
 final class _CypherNoId extends CypherId {
   const _CypherNoId() : super._();
 
@@ -101,8 +111,20 @@ final class _CypherNoId extends CypherId {
 
 /// Top-level helper function for json_serializable toJson conversion.
 /// Use with @JsonKey(toJson: cypherIdToJson)
+///
+/// **Deprecated:** Use [cypherElementIdToJson] with [CypherElementId] instead.
+@Deprecated(
+  'Use cypherElementIdToJson with CypherElementId instead. '
+  'The id() function is deprecated in Neo4j 5.0+.',
+)
 int? cypherIdToJson(CypherId id) => id.toJson();
 
 /// Top-level helper function for json_serializable fromJson conversion.
 /// Use with @JsonKey(fromJson: cypherIdFromJson)
+///
+/// **Deprecated:** Use [cypherElementIdFromJson] with [CypherElementId] instead.
+@Deprecated(
+  'Use cypherElementIdFromJson with CypherElementId instead. '
+  'The id() function is deprecated in Neo4j 5.0+.',
+)
 CypherId cypherIdFromJson(int? json) => CypherId.fromJson(json);

--- a/packages/dart_neo4j_ogm/pubspec.yaml
+++ b/packages/dart_neo4j_ogm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j_ogm
 description: Annotations for Neo4j Object-Graph Mapping (OGM) code generation in Dart.
-version: 0.2.0
+version: 1.0.0
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j_ogm
 

--- a/packages/dart_neo4j_ogm_generator/CHANGELOG.md
+++ b/packages/dart_neo4j_ogm_generator/CHANGELOG.md
@@ -1,3 +1,74 @@
+## 1.0.0
+
+### BREAKING CHANGES
+
+- **ID Field Validation**: Generator now accepts any field name for ID fields (not just `id`)
+  - Fields are identified by type (`CypherId` or `CypherElementId`) rather than name
+  - At least one ID field (either type) is required per `@cypherNode` class
+  - Only one occurrence of each ID type is allowed per class
+
+### New Features
+
+- **CypherElementId Support**: Full code generation support for `CypherElementId` type
+  - Generates `CypherElementId.value(node.elementIdOrThrow)` in `fromNode` factories
+  - Supports classes with only `CypherElementId` fields
+  - Supports classes with both `CypherId` and `CypherElementId` fields for gradual migration
+- **Flexible ID Field Naming**: ID fields can have any name (e.g., `elementId`, `nodeId`, `uid`)
+  - Generator identifies ID fields by type, not by field name
+  - Enables better semantic naming based on domain requirements
+- **Enhanced Validation**: Improved build-time error messages
+  - Clear errors if no ID field is present
+  - Clear errors if multiple fields of the same ID type exist
+  - Helpful suggestions for fixing validation errors
+
+### Improvements
+
+- **Code Quality**: Refactored `isIdField` to be a computed getter, eliminating desync risks
+- **Better Field Detection**: Enhanced field analysis for both regular and Freezed classes
+- **Comprehensive Tests**: Added test fixtures and tests for all ID type combinations
+  - Tests for `CypherId` only (backward compatibility)
+  - Tests for `CypherElementId` only (Neo4j 5.0+)
+  - Tests for both ID types (migration scenarios)
+
+### Technical Changes
+
+- Updated `FieldInfo` model with `isCypherIdField` and `isCypherElementIdField` properties
+- Updated `ClassInfo` model with `hasCypherId` and `hasCypherElementId` properties
+- Enhanced `_validateIdField()` to support both ID types with flexible naming
+- Updated Jinja template to conditionally generate appropriate ID field assignments
+- Refactored `isIdField` from stored field to computed getter for better consistency
+
+### Migration Guide
+
+Classes can now use `CypherElementId` for Neo4j 5.0+ compatibility:
+
+```dart
+// Neo4j 5.0+ style (recommended)
+@cypherNode
+class User {
+  final CypherElementId elementId;
+  final String name;
+
+  const User({required this.elementId, required this.name});
+  factory User.fromNode(Node node) => _$UserFromNode(node);
+}
+
+// Hybrid approach (for gradual migration)
+@cypherNode
+class User {
+  final CypherId legacyId;
+  final CypherElementId elementId;
+  final String name;
+
+  const User({
+    required this.legacyId,
+    required this.elementId,
+    required this.name,
+  });
+  factory User.fromNode(Node node) => _$UserFromNode(node);
+}
+```
+
 ## 0.2.0
 
 ### BREAKING CHANGES

--- a/packages/dart_neo4j_ogm_generator/analysis_options.yaml
+++ b/packages/dart_neo4j_ogm_generator/analysis_options.yaml
@@ -14,6 +14,10 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  exclude:
+    - test/fixtures/*.cypher.dart
+    - test/fixtures/*.g.dart
+    - test/fixtures/*.freezed.dart
   errors:
     invalid_annotation_target: ignore
 # Uncomment the following section to specify additional rules.

--- a/packages/dart_neo4j_ogm_generator/lib/src/generators/cypher_generator.dart
+++ b/packages/dart_neo4j_ogm_generator/lib/src/generators/cypher_generator.dart
@@ -101,8 +101,9 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
 
     // Check if we have fields available (normal case or after Freezed has run)
     if (processableFields.isNotEmpty) {
-      final idField =
-          processableFields.where((field) => field.name3 == 'id').firstOrNull;
+      final idField = processableFields
+          .where((field) => field.name3 == 'id')
+          .firstOrNull;
 
       if (idField == null) {
         throw InvalidGenerationSourceError(
@@ -123,10 +124,9 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
       final constructorFieldInfo = AnnotationReader.getFieldInfoFromConstructor(
         element,
       );
-      final idFieldData =
-          constructorFieldInfo
-              .where((fieldData) => fieldData['name'] == 'id')
-              .firstOrNull;
+      final idFieldData = constructorFieldInfo
+          .where((fieldData) => fieldData['name'] == 'id')
+          .firstOrNull;
 
       if (idFieldData == null) {
         throw InvalidGenerationSourceError(

--- a/packages/dart_neo4j_ogm_generator/lib/src/generators/cypher_generator.dart
+++ b/packages/dart_neo4j_ogm_generator/lib/src/generators/cypher_generator.dart
@@ -61,6 +61,12 @@ class CypherGenerator extends GeneratorForAnnotation<CypherNode> {
     final includeFromNode = AnnotationReader.extractIncludeFromNode(annotation);
     final fields = _extractFieldInfo(element);
 
+    // Determine which ID types are present
+    final hasCypherId = fields.any((field) => field.isCypherIdField);
+    final hasCypherElementId = fields.any(
+      (field) => field.isCypherElementIdField,
+    );
+
     // Validate factory constructor if includeFromNode is true
     if (includeFromNode) {
       _validateFromNodeFactory(element, className);
@@ -71,6 +77,8 @@ class CypherGenerator extends GeneratorForAnnotation<CypherNode> {
       label: label,
       fields: fields,
       includeFromNode: includeFromNode,
+      hasCypherId: hasCypherId,
+      hasCypherElementId: hasCypherElementId,
     );
   }
 
@@ -95,27 +103,43 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
     }
   }
 
-  /// Validates that the class has a required CypherId id field.
+  /// Validates that the class has at least one ID field (CypherId or CypherElementId).
+  /// Also validates that there is only one occurrence of each type.
   void _validateIdField(ClassElement2 element) {
     final processableFields = AnnotationReader.getProcessableFields(element);
 
     // Check if we have fields available (normal case or after Freezed has run)
     if (processableFields.isNotEmpty) {
-      final idField = processableFields
-          .where((field) => field.name3 == 'id')
-          .firstOrNull;
+      final cypherIdFields = processableFields
+          .where((field) => field.type.getDisplayString() == 'CypherId')
+          .toList();
+      final cypherElementIdFields = processableFields
+          .where((field) => field.type.getDisplayString() == 'CypherElementId')
+          .toList();
 
-      if (idField == null) {
+      // Validate at least one ID field exists
+      if (cypherIdFields.isEmpty && cypherElementIdFields.isEmpty) {
         throw InvalidGenerationSourceError(
-          'Classes annotated with @cypherNode must have a CypherId id field',
+          'Classes annotated with @cypherNode must have at least one ID field '
+          'of type CypherId or CypherElementId',
           element: element,
         );
       }
 
-      final idFieldType = idField.type.getDisplayString();
-      if (idFieldType != 'CypherId') {
+      // Validate only one occurrence of CypherId
+      if (cypherIdFields.length > 1) {
         throw InvalidGenerationSourceError(
-          'The id field must be of type CypherId, found: $idFieldType',
+          'Classes annotated with @cypherNode can only have one CypherId field. '
+          'Found ${cypherIdFields.length} fields: ${cypherIdFields.map((f) => f.name3).join(', ')}',
+          element: element,
+        );
+      }
+
+      // Validate only one occurrence of CypherElementId
+      if (cypherElementIdFields.length > 1) {
+        throw InvalidGenerationSourceError(
+          'Classes annotated with @cypherNode can only have one CypherElementId field. '
+          'Found ${cypherElementIdFields.length} fields: ${cypherElementIdFields.map((f) => f.name3).join(', ')}',
           element: element,
         );
       }
@@ -124,21 +148,36 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
       final constructorFieldInfo = AnnotationReader.getFieldInfoFromConstructor(
         element,
       );
-      final idFieldData = constructorFieldInfo
-          .where((fieldData) => fieldData['name'] == 'id')
-          .firstOrNull;
+      final cypherIdFields = constructorFieldInfo
+          .where((fieldData) => fieldData['type'] == 'CypherId')
+          .toList();
+      final cypherElementIdFields = constructorFieldInfo
+          .where((fieldData) => fieldData['type'] == 'CypherElementId')
+          .toList();
 
-      if (idFieldData == null) {
+      // Validate at least one ID field exists
+      if (cypherIdFields.isEmpty && cypherElementIdFields.isEmpty) {
         throw InvalidGenerationSourceError(
-          'Classes annotated with @cypherNode must have a CypherId id field',
+          'Classes annotated with @cypherNode must have at least one ID field '
+          'of type CypherId or CypherElementId',
           element: element,
         );
       }
 
-      final idFieldType = idFieldData['type'] as String;
-      if (idFieldType != 'CypherId') {
+      // Validate only one occurrence of CypherId
+      if (cypherIdFields.length > 1) {
         throw InvalidGenerationSourceError(
-          'The id field must be of type CypherId, found: $idFieldType',
+          'Classes annotated with @cypherNode can only have one CypherId field. '
+          'Found ${cypherIdFields.length} fields: ${cypherIdFields.map((f) => f['name']).join(', ')}',
+          element: element,
+        );
+      }
+
+      // Validate only one occurrence of CypherElementId
+      if (cypherElementIdFields.length > 1) {
+        throw InvalidGenerationSourceError(
+          'Classes annotated with @cypherNode can only have one CypherElementId field. '
+          'Found ${cypherElementIdFields.length} fields: ${cypherElementIdFields.map((f) => f['name']).join(', ')}',
           element: element,
         );
       }
@@ -155,7 +194,9 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
         final fieldName = field.name3 ?? 'unknownField';
         final fieldType = field.type.getDisplayString();
         final cypherName = AnnotationReader.getCypherPropertyName(field);
-        final isIdField = fieldName == 'id';
+        final isCypherIdField = fieldType == 'CypherId';
+        final isCypherElementIdField = fieldType == 'CypherElementId';
+        final isIdField = isCypherIdField || isCypherElementIdField;
         // Id fields are always ignored for Cypher properties, regardless of @CypherProperty annotation
         final isIgnored = isIdField || AnnotationReader.isFieldIgnored(field);
 
@@ -164,7 +205,8 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
           type: fieldType,
           cypherName: cypherName,
           isIgnored: isIgnored,
-          isIdField: isIdField,
+          isCypherIdField: isCypherIdField,
+          isCypherElementIdField: isCypherElementIdField,
         );
       }).toList();
     }
@@ -177,16 +219,20 @@ factory $className.fromNode(Node node) => _\$${className}FromNode(node);''';
 
     return constructorFieldInfo.map((fieldData) {
       final fieldName = fieldData['name'] as String;
-      final isIdField = fieldName == 'id';
+      final fieldType = fieldData['type'] as String;
+      final isCypherIdField = fieldType == 'CypherId';
+      final isCypherElementIdField = fieldType == 'CypherElementId';
+      final isIdField = isCypherIdField || isCypherElementIdField;
       // Id fields are always ignored for Cypher properties, regardless of @CypherProperty annotation
       final isIgnored = isIdField || (fieldData['isIgnored'] as bool);
 
       return FieldInfo(
         name: fieldName,
-        type: fieldData['type'] as String,
+        type: fieldType,
         cypherName: fieldData['cypherName'] as String,
         isIgnored: isIgnored,
-        isIdField: isIdField,
+        isCypherIdField: isCypherIdField,
+        isCypherElementIdField: isCypherElementIdField,
       );
     }).toList();
   }

--- a/packages/dart_neo4j_ogm_generator/lib/src/models/class_info.dart
+++ b/packages/dart_neo4j_ogm_generator/lib/src/models/class_info.dart
@@ -10,6 +10,8 @@ class ClassInfo {
     required this.label,
     required this.fields,
     this.includeFromNode = true,
+    this.hasCypherId = false,
+    this.hasCypherElementId = false,
   });
 
   /// The name of the annotated class.
@@ -24,6 +26,12 @@ class ClassInfo {
   /// Whether to generate the fromNode helper function.
   final bool includeFromNode;
 
+  /// Whether the class has a CypherId field.
+  final bool hasCypherId;
+
+  /// Whether the class has a CypherElementId field.
+  final bool hasCypherElementId;
+
   /// Converts the class info to a map for template rendering.
   Map<String, dynamic> toMap() {
     return {
@@ -31,6 +39,8 @@ class ClassInfo {
       'label': label,
       'fields': fields.map((field) => field.toMap()).toList(),
       'includeFromNode': includeFromNode,
+      'hasCypherId': hasCypherId,
+      'hasCypherElementId': hasCypherElementId,
     };
   }
 }

--- a/packages/dart_neo4j_ogm_generator/lib/src/models/field_info.dart
+++ b/packages/dart_neo4j_ogm_generator/lib/src/models/field_info.dart
@@ -8,7 +8,8 @@ class FieldInfo {
     required this.type,
     required this.cypherName,
     required this.isIgnored,
-    this.isIdField = false,
+    this.isCypherIdField = false,
+    this.isCypherElementIdField = false,
   });
 
   /// The original field name in the Dart class.
@@ -23,8 +24,14 @@ class FieldInfo {
   /// Whether this field should be ignored in Cypher generation.
   final bool isIgnored;
 
-  /// Whether this field is the mandatory id field.
-  final bool isIdField;
+  /// Whether this field is a CypherId field (legacy integer ID).
+  final bool isCypherIdField;
+
+  /// Whether this field is a CypherElementId field (Neo4j 5.0+ string element ID).
+  final bool isCypherElementIdField;
+
+  /// Whether this field is an ID field (either CypherId or CypherElementId).
+  bool get isIdField => isCypherIdField || isCypherElementIdField;
 
   /// Converts the field info to a map for template rendering.
   Map<String, dynamic> toMap() {
@@ -34,6 +41,8 @@ class FieldInfo {
       'cypherName': cypherName,
       'isIgnored': isIgnored,
       'isIdField': isIdField,
+      'isCypherIdField': isCypherIdField,
+      'isCypherElementIdField': isCypherElementIdField,
     };
   }
 }

--- a/packages/dart_neo4j_ogm_generator/lib/src/utils/annotation_reader.dart
+++ b/packages/dart_neo4j_ogm_generator/lib/src/utils/annotation_reader.dart
@@ -54,15 +54,14 @@ class AnnotationReader {
     final fields = element.fields2;
 
     // Remove synthetic and static fields
-    final processableFields =
-        fields
-            .where(
-              (field) =>
-                  !field.isSynthetic &&
-                  !field.isStatic &&
-                  !(field.name3?.startsWith('_') ?? false),
-            )
-            .toList();
+    final processableFields = fields
+        .where(
+          (field) =>
+              !field.isSynthetic &&
+              !field.isStatic &&
+              !(field.name3?.startsWith('_') ?? false),
+        )
+        .toList();
 
     // For Freezed classes, we might also need to check constructor parameters
     // if fields are not yet generated. This handles the case where the generator

--- a/packages/dart_neo4j_ogm_generator/pubspec.yaml
+++ b/packages/dart_neo4j_ogm_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j_ogm_generator
 description: Code generator for dart_neo4j_ogm annotations. Generates Cypher query construction methods for Neo4j OGM.
-version: 0.2.0
+version: 1.0.0
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j_ogm_generator
 

--- a/packages/dart_neo4j_ogm_generator/pubspec.yaml
+++ b/packages/dart_neo4j_ogm_generator/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   analyzer: ^7.7.1
 
   # Annotation package
-  dart_neo4j_ogm: ^0.2.0
+  dart_neo4j_ogm: ^1.0.0
 
 dev_dependencies:
   # Testing
@@ -27,8 +27,8 @@ dev_dependencies:
   build_test: ^3.0.0
 
   # Neo4j driver and bolt for integration tests
-  dart_neo4j: ^0.2.0
-  dart_bolt: ^0.2.0
+  dart_neo4j: ^1.0.0
+  dart_bolt: ^1.0.0
 
   # Freezed for testing compatibility
   freezed: ^3.2.0

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/freezed_user.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/freezed_user.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/hybrid_user.cypher.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/hybrid_user.cypher.dart
@@ -1,0 +1,80 @@
+// dart format width=80
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// CypherGenerator
+// **************************************************************************
+
+part of 'hybrid_user.dart';
+
+// Generated extension for HybridUser
+extension HybridUserCypher on HybridUser {
+  /// Returns a map of parameter names to values for Cypher queries.
+  Map<String, dynamic> get cypherParameters {
+    return {'username': username};
+  }
+
+  /// Returns Cypher node properties syntax string with parameter placeholders.
+  String get cypherProperties {
+    final props = <String>[];
+
+    props.add('username: \$username');
+
+    return '{${props.join(', ')}}';
+  }
+
+  /// Returns complete Cypher node syntax with variable name, label, and properties.
+  /// Example: `user.toCypherWithPlaceholders('u')` returns `'(u:User {id: $id, name: $name})'`
+  String toCypherWithPlaceholders(String variableName) {
+    return '($variableName:$nodeLabel $cypherProperties)';
+  }
+
+  /// Returns the Neo4j node label for this HybridUser.
+  String get nodeLabel => 'HybridUser';
+
+  /// Returns the list of property names used in Cypher queries.
+  List<String> get cypherPropertyNames => ['username'];
+
+  /// Returns Cypher node properties syntax string with prefixed parameter placeholders.
+  /// This helps avoid parameter name collisions in complex queries.
+  /// Example: `user.cypherPropertiesWithPrefix('user_')` returns `'{id: $user_id, name: $user_name}'`
+  String cypherPropertiesWithPrefix(String prefix) {
+    final props = <String>[];
+
+    props.add('username: \$${prefix}username');
+
+    return '{${props.join(', ')}}';
+  }
+
+  /// Returns a map of parameter names to values with the specified prefix.
+  /// This helps avoid parameter name collisions in complex queries.
+  /// Example: `user.cypherParametersWithPrefix('user_')` returns `{'user_id': '123', 'user_name': 'John'}`
+  Map<String, dynamic> cypherParametersWithPrefix(String prefix) {
+    return {'${prefix}username': username};
+  }
+
+  /// Returns complete Cypher node syntax with variable name, label, and prefixed properties.
+  /// This helps avoid parameter name collisions in complex queries.
+  /// Example: `user.toCypherWithPlaceholdersWithPrefix('u', 'user_')` returns `'(u:User {id: $user_id, name: $user_name})'`
+  String toCypherWithPlaceholdersWithPrefix(
+    String variableName,
+    String prefix,
+  ) {
+    return '($variableName:$nodeLabel ${cypherPropertiesWithPrefix(prefix)})';
+  }
+}
+
+/// Private function to create HybridUser from Neo4j Node object.
+/// Use this in a factory constructor like:
+/// `factory HybridUser.fromNode(Node node) => _$HybridUserFromNode(node);`
+HybridUser _$HybridUserFromNode(Node node) {
+  final props = node.properties;
+
+  return HybridUser(
+    legacyId: CypherId.value(node.id),
+
+    elementId: CypherElementId.value(node.elementIdOrThrow),
+
+    username: props['username'] as String,
+  );
+}

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/hybrid_user.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/hybrid_user.dart
@@ -1,0 +1,21 @@
+// ignore_for_file: deprecated_member_use
+
+import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
+import 'package:dart_neo4j/dart_neo4j.dart';
+
+part 'hybrid_user.cypher.dart';
+
+@cypherNode
+class HybridUser {
+  final CypherId legacyId;
+  final CypherElementId elementId;
+  final String username;
+
+  const HybridUser({
+    required this.legacyId,
+    required this.elementId,
+    required this.username,
+  });
+
+  factory HybridUser.fromNode(Node node) => _$HybridUserFromNode(node);
+}

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/json_user.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/json_user.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
 import 'package:dart_neo4j/dart_neo4j.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/modern_user.cypher.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/modern_user.cypher.dart
@@ -1,0 +1,84 @@
+// dart format width=80
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// CypherGenerator
+// **************************************************************************
+
+part of 'modern_user.dart';
+
+// Generated extension for ModernUser
+extension ModernUserCypher on ModernUser {
+  /// Returns a map of parameter names to values for Cypher queries.
+  Map<String, dynamic> get cypherParameters {
+    return {'name': name, 'email': email};
+  }
+
+  /// Returns Cypher node properties syntax string with parameter placeholders.
+  String get cypherProperties {
+    final props = <String>[];
+
+    props.add('name: \$name');
+
+    props.add('email: \$email');
+
+    return '{${props.join(', ')}}';
+  }
+
+  /// Returns complete Cypher node syntax with variable name, label, and properties.
+  /// Example: `user.toCypherWithPlaceholders('u')` returns `'(u:User {id: $id, name: $name})'`
+  String toCypherWithPlaceholders(String variableName) {
+    return '($variableName:$nodeLabel $cypherProperties)';
+  }
+
+  /// Returns the Neo4j node label for this ModernUser.
+  String get nodeLabel => 'ModernUser';
+
+  /// Returns the list of property names used in Cypher queries.
+  List<String> get cypherPropertyNames => ['name', 'email'];
+
+  /// Returns Cypher node properties syntax string with prefixed parameter placeholders.
+  /// This helps avoid parameter name collisions in complex queries.
+  /// Example: `user.cypherPropertiesWithPrefix('user_')` returns `'{id: $user_id, name: $user_name}'`
+  String cypherPropertiesWithPrefix(String prefix) {
+    final props = <String>[];
+
+    props.add('name: \$${prefix}name');
+
+    props.add('email: \$${prefix}email');
+
+    return '{${props.join(', ')}}';
+  }
+
+  /// Returns a map of parameter names to values with the specified prefix.
+  /// This helps avoid parameter name collisions in complex queries.
+  /// Example: `user.cypherParametersWithPrefix('user_')` returns `{'user_id': '123', 'user_name': 'John'}`
+  Map<String, dynamic> cypherParametersWithPrefix(String prefix) {
+    return {'${prefix}name': name, '${prefix}email': email};
+  }
+
+  /// Returns complete Cypher node syntax with variable name, label, and prefixed properties.
+  /// This helps avoid parameter name collisions in complex queries.
+  /// Example: `user.toCypherWithPlaceholdersWithPrefix('u', 'user_')` returns `'(u:User {id: $user_id, name: $user_name})'`
+  String toCypherWithPlaceholdersWithPrefix(
+    String variableName,
+    String prefix,
+  ) {
+    return '($variableName:$nodeLabel ${cypherPropertiesWithPrefix(prefix)})';
+  }
+}
+
+/// Private function to create ModernUser from Neo4j Node object.
+/// Use this in a factory constructor like:
+/// `factory ModernUser.fromNode(Node node) => _$ModernUserFromNode(node);`
+ModernUser _$ModernUserFromNode(Node node) {
+  final props = node.properties;
+
+  return ModernUser(
+    elementId: CypherElementId.value(node.elementIdOrThrow),
+
+    name: props['name'] as String,
+
+    email: props['email'] as String,
+  );
+}

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/modern_user.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/modern_user.dart
@@ -1,0 +1,19 @@
+import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
+import 'package:dart_neo4j/dart_neo4j.dart';
+
+part 'modern_user.cypher.dart';
+
+@cypherNode
+class ModernUser {
+  final CypherElementId elementId;
+  final String name;
+  final String email;
+
+  const ModernUser({
+    required this.elementId,
+    required this.name,
+    required this.email,
+  });
+
+  factory ModernUser.fromNode(Node node) => _$ModernUserFromNode(node);
+}

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/person.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/person.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
 import 'package:dart_neo4j/dart_neo4j.dart';
 

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/product.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/product.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
 
 part 'product.cypher.dart';

--- a/packages/dart_neo4j_ogm_generator/test/fixtures/user.dart
+++ b/packages/dart_neo4j_ogm_generator/test/fixtures/user.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'package:dart_neo4j_ogm/dart_neo4j_ogm.dart';
 import 'package:dart_neo4j/dart_neo4j.dart';
 

--- a/packages/dart_neo4j_ogm_generator/test/integration/neo4j_integration_test.dart
+++ b/packages/dart_neo4j_ogm_generator/test/integration/neo4j_integration_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use
+
 import 'dart:io';
 
 import 'package:dart_neo4j/dart_neo4j.dart';

--- a/packages/dart_neo4j_ogm_generator/views/cypher_extension.jinja
+++ b/packages/dart_neo4j_ogm_generator/views/cypher_extension.jinja
@@ -84,9 +84,12 @@ extension {{ className }}Cypher on {{ className }} {
   final props = node.properties;
 
   return {{ className }}(
-    id: CypherId.value(node.id),
     {% for field in fields %}
-    {% if not field['isIgnored'] and not field['isIdField'] %}
+    {% if field['isCypherIdField'] %}
+    {{ field['name'] }}: CypherId.value(node.id),
+    {% elif field['isCypherElementIdField'] %}
+    {{ field['name'] }}: CypherElementId.value(node.elementIdOrThrow),
+    {% elif not field['isIgnored'] %}
     {{ field['name'] }}: props['{{ field['cypherName'] }}'] as {{ field['type'] }},
     {% endif %}
     {% endfor %}

--- a/packages/dart_packstream/lib/src/data_types/ps_bytes.dart
+++ b/packages/dart_packstream/lib/src/data_types/ps_bytes.dart
@@ -141,30 +141,27 @@ final class PsBytes extends PsDataType<Uint8List, Uint8List>
 
     if (length <= 0xFF) {
       // 8-bit size
-      bytes =
-          ByteData(2 + length)
-            ..setUint8(0, 0xCC)
-            ..setUint8(1, length);
+      bytes = ByteData(2 + length)
+        ..setUint8(0, 0xCC)
+        ..setUint8(1, length);
 
       for (var i = 0; i < length; i++) {
         bytes.setUint8(2 + i, value[i]);
       }
     } else if (length <= 0xFFFF) {
       // 16-bit size
-      bytes =
-          ByteData(3 + length)
-            ..setUint8(0, 0xCD)
-            ..setUint16(1, length, Endian.big);
+      bytes = ByteData(3 + length)
+        ..setUint8(0, 0xCD)
+        ..setUint16(1, length, Endian.big);
 
       for (var i = 0; i < length; i++) {
         bytes.setUint8(3 + i, value[i]);
       }
     } else {
       // 32-bit size
-      bytes =
-          ByteData(5 + length)
-            ..setUint8(0, 0xCE)
-            ..setUint32(1, length, Endian.big);
+      bytes = ByteData(5 + length)
+        ..setUint8(0, 0xCE)
+        ..setUint32(1, length, Endian.big);
 
       for (var i = 0; i < length; i++) {
         bytes.setUint8(5 + i, value[i]);

--- a/packages/dart_packstream/lib/src/data_types/ps_dictionary.dart
+++ b/packages/dart_packstream/lib/src/data_types/ps_dictionary.dart
@@ -46,10 +46,9 @@ final class PsDictionary
     // Any non-PsString keys should be handled by the fromDictionary helper method
     for (final entry in values.entries) {
       final key = entry.key as PsString;
-      final value =
-          entry.value is PsDataType
-              ? entry.value as PsDataType
-              : PsDataType.fromValue(entry.value);
+      final value = entry.value is PsDataType
+          ? entry.value as PsDataType
+          : PsDataType.fromValue(entry.value);
 
       _values[key] = value;
     }

--- a/packages/dart_packstream/lib/src/ps_data_type.dart
+++ b/packages/dart_packstream/lib/src/ps_data_type.dart
@@ -167,10 +167,9 @@ sealed class PsDataType<T, D> {
           == 0xD9 ||
           == 0xDA => PsDictionary.fromPackStreamBytes(bytes),
           >= 0xB0 && <= 0xBF => _parseStructure(firstByte, bytes),
-          _ =>
-            throw ArgumentError(
-              'Invalid PackStream marker byte: 0x${firstByte.toRadixString(16)}',
-            ),
+          _ => throw ArgumentError(
+            'Invalid PackStream marker byte: 0x${firstByte.toRadixString(16)}',
+          ),
         }
         as PsDataType<T, D>;
   }

--- a/packages/dart_packstream/pubspec.yaml
+++ b/packages/dart_packstream/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_packstream
 description: A Dart library for serializing and deserializing data using the Packstream format.
-version: 0.2.0
+version: 1.0.0
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_packstream
 

--- a/packages/dart_packstream/test/src/data_types/ps_dictionary_test.dart
+++ b/packages/dart_packstream/test/src/data_types/ps_dictionary_test.dart
@@ -244,10 +244,9 @@ void main() {
       );
 
       // Dictionary with size but no data
-      final insufficientBytes2 =
-          ByteData(2)
-            ..setUint8(0, 0xD8)
-            ..setUint8(1, 1);
+      final insufficientBytes2 = ByteData(2)
+        ..setUint8(0, 0xD8)
+        ..setUint8(1, 1);
       expect(
         () => PsDictionary.fromPackStreamBytes(insufficientBytes2),
         throwsA(isA<ArgumentError>()),
@@ -256,12 +255,11 @@ void main() {
 
     test('throws ArgumentError if key is not a string', () {
       // Mock a dictionary where the key is not a string
-      final invalidKeyBytes =
-          ByteData(4)
-            ..setUint8(0, 0xA1) // Dictionary with 1 entry
-            ..setUint8(1, 0x01) // Integer key (invalid)
-            ..setUint8(2, 0x81) // String value marker
-            ..setUint8(3, 0x61); // 'a'
+      final invalidKeyBytes = ByteData(4)
+        ..setUint8(0, 0xA1) // Dictionary with 1 entry
+        ..setUint8(1, 0x01) // Integer key (invalid)
+        ..setUint8(2, 0x81) // String value marker
+        ..setUint8(3, 0x61); // 'a'
       expect(
         () => PsDictionary.fromPackStreamBytes(invalidKeyBytes),
         throwsA(

--- a/packages/dart_packstream/test/src/data_types/ps_tiny_int_test.dart
+++ b/packages/dart_packstream/test/src/data_types/ps_tiny_int_test.dart
@@ -109,10 +109,9 @@ void main() {
     });
 
     test('throws ArgumentError for ByteData with too many bytes', () {
-      final tooManyBytes =
-          ByteData(2)
-            ..setUint8(0, 0x00)
-            ..setUint8(1, 0x00);
+      final tooManyBytes = ByteData(2)
+        ..setUint8(0, 0x00)
+        ..setUint8(1, 0x00);
       expect(
         () => PsTinyInt.fromPackStreamBytes(tooManyBytes),
         throwsA(


### PR DESCRIPTION
## 🎉 Version 1.0.0 Release

This PR adds full support for Neo4j 5.0+ element IDs and releases version 1.0.0 for all packages.

## 📦 Package Changes

### dart_packstream (1.0.0)
- First stable release

### dart_bolt (1.0.0)
- First stable release

### dart_neo4j (1.0.0)
**BREAKING CHANGES:**
- Deprecated numeric `id` property on `Node`, `Relationship`, and `UnboundRelationship`

**New Features:**
- Added `elementId` (nullable) and `elementIdOrThrow` properties for Neo4j 5.0+ compatibility
- Improved equality comparisons to prefer `elementId` when available
- Enhanced `toString` to include `elementId`

### dart_neo4j_ogm (1.0.0)
**BREAKING CHANGES:**
- Deprecated `CypherId` type in favor of `CypherElementId`

**New Features:**
- New `CypherElementId` sealed class for string-based element IDs
- Support for dual ID types (both `CypherId` and `CypherElementId` in same class)
- JSON serialization helpers for `CypherElementId`

### dart_neo4j_ogm_generator (1.0.0)
**BREAKING CHANGES:**
- ID field validation now requires at least one `CypherId` or `CypherElementId` field
- Maximum one field of each ID type per class

**New Features:**
- Support for `CypherElementId` in code generation
- Flexible ID field naming (no longer enforces specific names like `id` or `elementId`)
- Generated `fromNode` factory handles both ID types correctly

## 🔄 Migration Path

The changes provide a smooth migration path:
1. Existing code with `CypherId` continues to work (with deprecation warnings)
2. New code can use `CypherElementId` for Neo4j 5.0+ compatibility
3. Hybrid classes can have both ID types during migration
4. ID field names are now flexible (based on type, not name)

## 📚 Documentation

- Updated all CHANGELOGs with version 1.0.0 entries
- Updated dart_neo4j_ogm README with comprehensive usage examples
- Added migration guides and examples for all breaking changes

## ✅ Testing

- Added comprehensive tests for `CypherElementId`
- Added `ModernUser` and `HybridUser` test fixtures
- All existing tests pass with backward compatibility maintained