### PR TITLE
Allow for long running queries

### DIFF
--- a/dpk.yaml
+++ b/dpk.yaml
@@ -1,3 +1,5 @@
+version: ^0.6.5
+
 catalog:
   resolution: workspace
   repository: https://github.com/exaby73/dart_neo4j/tree/main/DPK_PACKAGE_PATH

--- a/packages/dart_neo4j/CHANGELOG.md
+++ b/packages/dart_neo4j/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1-wip
+
+- Add optional `timeout` parameter to `BoltConnection.run` (and `BoltConnection._sendMessage`, with default set to 30 seconds for backward compatibility); the timeout is used on the `pull` message.
+- Add optional `timeout` parameter to `SessionConfiguration` (defaults to 30 seconds) and use that timeout when running queries directly over the session.
+- Use `TransactionConfig.timeout` when running queries over a transaction.
+
 ## 1.2.0
 
 - Version bump for consistency with dart_neo4j ecosystem

--- a/packages/dart_neo4j/CHANGELOG.md
+++ b/packages/dart_neo4j/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add optional `timeout` parameter to `BoltConnection.run` (and `BoltConnection._sendMessage`, with default set to 30 seconds for backward compatibility); the timeout is used on the `pull` message.
 - Add optional `timeout` parameter to `SessionConfiguration` (defaults to 30 seconds) and use that timeout when running queries directly over the session.
 - Use `TransactionConfig.timeout` when running queries over a transaction.
+- Implement `startQuery()` methods in addition to the existing `run()` methods. The existing implementations of `run()` returns only after all records have been streamed from the server. `startQuery()` returns before the query has fully executing, allowing for early streaming of records by clients. The query has finished executing when [Result.done] and [Result.summary()] complete (they are based on the same future).
 
 ## 1.2.0
 

--- a/packages/dart_neo4j/lib/dart_neo4j.dart
+++ b/packages/dart_neo4j/lib/dart_neo4j.dart
@@ -78,7 +78,7 @@ export 'src/session/transaction.dart';
 export 'src/connection/connection_pool.dart';
 
 // Results and types
-export 'src/result/result.dart';
+export 'src/result/result.dart' hide ResultPrivateImpl;
 export 'src/result/record.dart';
 export 'src/result/summary.dart';
 export 'src/types/neo4j_types.dart';

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -425,7 +425,6 @@ class BoltConnection {
       _protocol.sendMessage(message);
 
       timeout ??= const Duration(seconds: 30);
-      print('send $message with $timeout');
       return await completer.future.timeout(
         timeout,
         onTimeout: () {

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -19,15 +19,12 @@ class BoltConnection {
   late final BoltProtocol _protocol;
 
   BoltServerState _serverState = BoltServerState.disconnected;
-  final Map<int, Completer<BoltMessage>> _pendingRequests = {};
-  int _nextRequestId = 1;
+  final List<Completer<BoltMessage>> _pendingRequests = [];
 
   // Streaming result tracking
   Result? _currentStreamingResult;
   List<String>? _currentStreamingKeys;
 
-  final StreamController<BoltMessage> _messageController =
-      StreamController<BoltMessage>.broadcast();
   StreamSubscription<Uint8List>? _dataSubscription;
 
   /// Creates a new Bolt connection.
@@ -299,8 +296,13 @@ class BoltConnection {
     }
   }
 
-  /// Runs a Cypher query and returns the result.
-  Future<Result> run(
+  /// Runs a Cypher query and returns the result immediately.
+  ///
+  /// This method returns before the `PULL` operation is complete. It means
+  /// [Result] can be used for streaming records immediately, but the query
+  /// is still executing until [Result.done] completes. In the meantime, the
+  /// connection is busy and cannot accept new requests.
+  Future<Result> startQuery(
     String cypher, [
     Map<String, dynamic> parameters = const {},
     Duration? timeout,
@@ -411,7 +413,7 @@ class BoltConnection {
           if (ex is ConnectionTimeoutException) {
             result.completeWithError(
               Exception(
-                'The PULL operation has been cancelled after ${timeout}.',
+                'The PULL operation has been cancelled after $timeout.',
               ),
               st,
             );
@@ -430,14 +432,26 @@ class BoltConnection {
     }
   }
 
+  /// Runs a Cypher query and returns the result.
+  ///
+  /// This method returns after the query has finished executing.
+  Future<Result> run(
+    String cypher, [
+    Map<String, dynamic> parameters = const {},
+    Duration? timeout,
+  ]) async {
+    final result = await startQuery(cypher, parameters, timeout);
+    await result.done;
+    return result;
+  }
+
   /// Sends a message and waits for a response.
   Future<BoltMessage> _sendMessage(
     BoltMessage message, [
     Duration? timeout,
   ]) async {
-    final requestId = _nextRequestId++;
     final completer = Completer<BoltMessage>();
-    _pendingRequests[requestId] = completer;
+    _pendingRequests.add(completer);
 
     if (_currentStreamingResult != null) {
       throw ProtocolException(
@@ -452,7 +466,7 @@ class BoltConnection {
       return await completer.future.timeout(
         timeout,
         onTimeout: () {
-          _pendingRequests.remove(requestId);
+          _pendingRequests.remove(completer);
           throw ConnectionTimeoutException(
             'Message timeout: no response received',
             timeout,
@@ -460,7 +474,7 @@ class BoltConnection {
         },
       );
     } catch (e) {
-      _pendingRequests.remove(requestId);
+      _pendingRequests.remove(completer);
       rethrow;
     }
   }
@@ -490,15 +504,12 @@ class BoltConnection {
       }
 
       // Don't complete requests yet - wait for summary message
-      if (!_messageController.isClosed) {
-        _messageController.add(message);
-      }
     } else if (message is BoltSuccessMessage ||
         message is BoltFailureMessage ||
         message is BoltIgnoredMessage) {
       // Summary messages complete the current request
       if (_pendingRequests.isNotEmpty) {
-        final completer = _pendingRequests.values.first;
+        final completer = _pendingRequests.first;
         _pendingRequests.clear();
         completer.complete(message);
       }
@@ -506,20 +517,12 @@ class BoltConnection {
       // Clear streaming state
       _currentStreamingResult = null;
       _currentStreamingKeys = null;
-
-      if (!_messageController.isClosed) {
-        _messageController.add(message);
-      }
     } else {
       // Other messages complete requests immediately
       if (_pendingRequests.isNotEmpty) {
-        final completer = _pendingRequests.values.first;
+        final completer = _pendingRequests.first;
         _pendingRequests.clear();
         completer.complete(message);
-      }
-
-      if (!_messageController.isClosed) {
-        _messageController.add(message);
       }
     }
   }
@@ -529,16 +532,12 @@ class BoltConnection {
     _serverState = BoltServerState.defunct;
 
     // Complete all pending requests with error
-    for (final completer in _pendingRequests.values) {
+    for (final completer in _pendingRequests) {
       if (!completer.isCompleted) {
         completer.completeError(error, stackTrace);
       }
     }
     _pendingRequests.clear();
-
-    if (!_messageController.isClosed) {
-      _messageController.addError(error, stackTrace);
-    }
   }
 
   /// Handles connection close events.
@@ -616,16 +615,12 @@ class BoltConnection {
     await _socket.close();
 
     // Complete pending requests with error
-    for (final completer in _pendingRequests.values) {
+    for (final completer in _pendingRequests) {
       if (!completer.isCompleted) {
         completer.completeError(const ConnectionException('Connection closed'));
       }
     }
     _pendingRequests.clear();
-
-    if (!_messageController.isClosed) {
-      await _messageController.close();
-    }
   }
 
   @override

--- a/packages/dart_neo4j/lib/src/result/result.dart
+++ b/packages/dart_neo4j/lib/src/result/result.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:dart_neo4j/src/exceptions/neo4j_exception.dart';
 import 'package:dart_neo4j/src/result/record.dart';
 import 'package:dart_neo4j/src/result/summary.dart';
@@ -38,6 +39,9 @@ class Result {
 
   /// Whether this result has been consumed.
   bool get isConsumed => _isConsumed;
+
+  /// Future that completes when the query has finished executing.
+  Future<void> get done => _summaryCompleter.future;
 
   /// Stream of records from this result.
   ///
@@ -104,6 +108,14 @@ class Result {
     return summary();
   }
 
+  @override
+  String toString() {
+    return 'Result{keys: $keys, consumed: $_isConsumed}';
+  }
+}
+
+/// [Result] methods for internal use only.
+extension ResultPrivateImpl on Result {
   /// Adds a record to this result (internal use only).
   void addRecord(Record record) {
     if (!_recordController.isClosed) {
@@ -136,96 +148,5 @@ class Result {
     if (!_summaryCompleter.isCompleted) {
       _summaryCompleter.completeError(error, stackTrace);
     }
-  }
-
-  @override
-  String toString() {
-    return 'Result{keys: $keys, consumed: $_isConsumed}';
-  }
-}
-
-/// A completed result that contains all records in memory.
-class CompletedResult {
-  final List<String> _keys;
-  final List<Record> _records;
-  final ResultSummary _summary;
-
-  /// Creates a new completed result.
-  const CompletedResult._(this._keys, this._records, this._summary);
-
-  /// Creates a completed result from a list of records and summary.
-  factory CompletedResult.fromRecords(
-    List<String> keys,
-    List<Record> records,
-    ResultSummary summary,
-  ) {
-    return CompletedResult._(keys, records, summary);
-  }
-
-  /// The keys (column names) for this result.
-  List<String> get keys => List.unmodifiable(_keys);
-
-  /// All records in this result.
-  List<Record> get records => List.unmodifiable(_records);
-
-  /// The summary for this result.
-  ResultSummary get summary => _summary;
-
-  /// The number of records in this result.
-  int get length => _records.length;
-
-  /// Whether this result is empty.
-  bool get isEmpty => _records.isEmpty;
-
-  /// Whether this result is not empty.
-  bool get isNotEmpty => _records.isNotEmpty;
-
-  /// Gets the record at the given index.
-  Record operator [](int index) {
-    return _records[index];
-  }
-
-  /// Returns the single record from this result.
-  ///
-  /// Throws [ClientException] if the result contains zero or more than one record.
-  Record single() {
-    if (_records.isEmpty) {
-      throw ClientException('Expected single record but result was empty');
-    }
-    if (_records.length > 1) {
-      throw ClientException(
-        'Expected single record but got ${_records.length} records',
-      );
-    }
-    return _records.first;
-  }
-
-  /// Returns the first record from this result, or null if empty.
-  Record? firstOrNull() {
-    return _records.isNotEmpty ? _records.first : null;
-  }
-
-  /// Returns the last record from this result, or null if empty.
-  Record? lastOrNull() {
-    return _records.isNotEmpty ? _records.last : null;
-  }
-
-  @override
-  String toString() {
-    return 'CompletedResult{keys: $keys, records: ${_records.length}, summary: $summary}';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    return other is CompletedResult &&
-        other._keys.length == _keys.length &&
-        other._records.length == _records.length &&
-        other.summary == summary;
-  }
-
-  @override
-  int get hashCode {
-    return Object.hash(_keys.length, _records.length, summary);
   }
 }

--- a/packages/dart_neo4j/lib/src/session/session.dart
+++ b/packages/dart_neo4j/lib/src/session/session.dart
@@ -22,24 +22,36 @@ class SessionConfig {
   /// Bookmarks for causal consistency.
   final List<String> bookmarks;
 
+  /// Default query timeout.
+  final Duration timeout;
+
   /// Creates a new session configuration.
   const SessionConfig({
     this.database,
     this.accessMode = AccessMode.write,
     this.bookmarks = const [],
-  });
+    Duration? timeout,
+  }) : timeout = timeout ?? const Duration(seconds: 30);
 
   /// Creates a read-only session configuration.
-  const SessionConfig.read({this.database, this.bookmarks = const []})
-    : accessMode = AccessMode.read;
+  const SessionConfig.read({
+    this.database,
+    this.bookmarks = const [],
+    Duration? timeout,
+  }) : accessMode = AccessMode.read,
+       timeout = timeout ?? const Duration(seconds: 30);
 
   /// Creates a read-write session configuration.
-  const SessionConfig.write({this.database, this.bookmarks = const []})
-    : accessMode = AccessMode.write;
+  const SessionConfig.write({
+    this.database,
+    this.bookmarks = const [],
+    Duration? timeout,
+  }) : accessMode = AccessMode.write,
+       timeout = timeout ?? const Duration(seconds: 30);
 
   @override
   String toString() {
-    return 'SessionConfig{database: $database, accessMode: $accessMode, bookmarks: ${bookmarks.length}}';
+    return 'SessionConfig{database: $database, accessMode: $accessMode, bookmarks: ${bookmarks.length}, timeout: $timeout}';
   }
 }
 

--- a/packages/dart_neo4j/lib/src/session/session.dart
+++ b/packages/dart_neo4j/lib/src/session/session.dart
@@ -66,7 +66,23 @@ abstract class Session {
   /// The last bookmarks from this session.
   List<String> get lastBookmarks;
 
-  /// Executes a Cypher query in an auto-commit transaction.
+  /// Starts executing a Cypher query in an auto-commit transaction and returns
+  /// [Result] early so clients can start streaming records immediately.
+  /// [Result.done] and [Result.summary()] will complete when the query has
+  /// finished executing.
+  ///
+  /// [cypher] - the Cypher query to execute
+  /// [parameters] - parameters for the query (default: empty)
+  ///
+  /// Throws [SessionExpiredException] if the session is closed.
+  /// Throws [DatabaseException] if the query fails.
+  Future<Result> startQuery(
+    String cypher, [
+    Map<String, dynamic> parameters = const {},
+  ]);
+
+  /// Executes a Cypher query in an auto-commit transaction and wait for the
+  /// query to complete with all results.
   ///
   /// [cypher] - the Cypher query to execute
   /// [parameters] - parameters for the query (default: empty)

--- a/packages/dart_neo4j/lib/src/session/session_impl.dart
+++ b/packages/dart_neo4j/lib/src/session/session_impl.dart
@@ -42,7 +42,11 @@ class SessionImpl implements Session {
       pooledConnection = await _connectionPool.acquire();
 
       // Execute query
-      final result = await pooledConnection.connection.run(cypher, parameters);
+      final result = await pooledConnection.connection.run(
+        cypher,
+        parameters,
+        config.timeout,
+      );
 
       // Release connection back to pool immediately for auto-commit transactions
       _connectionPool.release(pooledConnection);

--- a/packages/dart_neo4j/lib/src/session/session_impl.dart
+++ b/packages/dart_neo4j/lib/src/session/session_impl.dart
@@ -28,6 +28,42 @@ class SessionImpl implements Session {
   List<String> get lastBookmarks => List.unmodifiable(_lastBookmarks);
 
   @override
+  Future<Result> startQuery(
+    String cypher, [
+    Map<String, dynamic> parameters = const {},
+  ]) async {
+    if (_closed) {
+      throw const SessionExpiredException('Session has been closed');
+    }
+
+    PooledConnection? pooledConnection;
+    try {
+      // Acquire connection from pool
+      pooledConnection = await _connectionPool.acquire();
+
+      // Execute query
+      final result = await pooledConnection.connection.startQuery(
+        cypher,
+        parameters,
+        config.timeout,
+      );
+
+      // Release connection back to pool when result has completed.
+      result.done.whenComplete(() {
+        _connectionPool.release(pooledConnection!);
+      });
+
+      return result;
+    } catch (e) {
+      // Release connection on error
+      if (pooledConnection != null) {
+        _connectionPool.release(pooledConnection);
+      }
+      rethrow;
+    }
+  }
+
+  @override
   Future<Result> run(
     String cypher, [
     Map<String, dynamic> parameters = const {},

--- a/packages/dart_neo4j/lib/src/session/transaction.dart
+++ b/packages/dart_neo4j/lib/src/session/transaction.dart
@@ -32,7 +32,23 @@ abstract class Transaction {
   /// Whether this transaction is marked for rollback.
   bool get isMarkedForRollback => state == TransactionState.markedForRollback;
 
-  /// Executes a Cypher query within this transaction.
+  /// Starts executing a Cypher query within this transaction and returns
+  /// [Result] early so clients can start streaming records immediately.
+  /// [Result.done] and [Result.summary()] will complete when the query has
+  /// finished executing.
+  ///
+  /// [cypher] - the Cypher query to execute
+  /// [parameters] - parameters for the query (default: empty)
+  ///
+  /// Throws [SessionExpiredException] if the session is closed.
+  /// Throws [DatabaseException] if the query fails.
+  Future<Result> startQuery(
+    String cypher, [
+    Map<String, dynamic> parameters = const {},
+  ]);
+
+  /// Executes a Cypher query within this transaction and wait for the
+  /// query to complete with all results.
   ///
   /// [cypher] - the Cypher query to execute
   /// [parameters] - parameters for the query (default: empty)

--- a/packages/dart_neo4j/lib/src/session/transaction_impl.dart
+++ b/packages/dart_neo4j/lib/src/session/transaction_impl.dart
@@ -44,7 +44,11 @@ abstract class TransactionImpl implements Transaction {
     }
 
     try {
-      return await _pooledConnection.connection.run(cypher, parameters);
+      return await _pooledConnection.connection.run(
+        cypher,
+        parameters,
+        config?.timeout,
+      );
     } catch (e) {
       _state = TransactionState.markedForRollback;
       rethrow;

--- a/packages/dart_neo4j/lib/src/session/transaction_impl.dart
+++ b/packages/dart_neo4j/lib/src/session/transaction_impl.dart
@@ -30,6 +30,37 @@ abstract class TransactionImpl implements Transaction {
   bool get isMarkedForRollback => _state == TransactionState.markedForRollback;
 
   @override
+  Future<Result> startQuery(
+    String cypher, [
+    Map<String, dynamic> parameters = const {},
+  ]) async {
+    if (isClosed) {
+      throw const TransactionClosedException('Transaction is closed');
+    }
+    if (isMarkedForRollback) {
+      throw const TransactionClosedException(
+        'Transaction is marked for rollback',
+      );
+    }
+
+    try {
+      final result = await _pooledConnection.connection.run(
+        cypher,
+        parameters,
+        config?.timeout,
+      );
+      result.done.catchError((e) {
+        _state = TransactionState.markedForRollback;
+        throw e;
+      });
+      return result;
+    } catch (e) {
+      _state = TransactionState.markedForRollback;
+      rethrow;
+    }
+  }
+
+  @override
   Future<Result> run(
     String cypher, [
     Map<String, dynamic> parameters = const {},

--- a/packages/dart_neo4j/pubspec.yaml
+++ b/packages/dart_neo4j/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j
 description: A comprehensive Neo4j driver for Dart supporting both bolt:// and neo4j:// URI schemes with type-safe result access.
-version: 1.2.0
+version: 1.2.1-wip
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j
 

--- a/packages/dart_neo4j/pubspec.yaml
+++ b/packages/dart_neo4j/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j
 description: A comprehensive Neo4j driver for Dart supporting both bolt:// and neo4j:// URI schemes with type-safe result access.
-version: 1.2.1-wip
+version: 1.2.1-wip-workflow
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j
 


### PR DESCRIPTION
I have a long-running query that systematically times out after 30 seconds. I've tried using transactions with a longer timeout but it did not help.

While the transaction timeout is sent to Neo4j (server-side timeout, which Neo4j can choose to trigger), there is also a hard-coded timeout in `_sendMessage` (client-side timeout):

https://github.com/exaby73/dart_neo4j/blob/a8bca6943437d33d2fc78d0b66bdffc030f61445/packages/dart_neo4j/lib/src/connection/bolt_connection.dart#L421-L432

This pull request is an attempt at fixing this issue. The idea is to provide a longer timeout for `pull` operations. I've tried to keep it minimal so it doesn't break existing code. When running a query over a transaction, the `TransactionConfig.timeout` will be used if set. I've also added an optional `timeout` to `SessionConfig` (with default = 30 sec) so queries executed directly over a session will also benefit from that behavior.
