### PR TITLE
Add support for legacy auth flow (protocol version < 5.1)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,6 @@ services:
     networks:
       - neo4j-network
 
-
 volumes:
   neo4j-single-data:
   neo4j-single-logs:

--- a/dpk.yaml
+++ b/dpk.yaml
@@ -8,11 +8,11 @@ catalog:
     sdk: ^3.8.0
 
   dependencies:
-    dart_bolt: ^1.2.1
-    dart_neo4j: ^1.2.1
-    dart_neo4j_ogm: ^1.2.1
-    dart_neo4j_ogm_generator: ^1.2.1
-    dart_packstream: ^1.2.1
+    dart_bolt: ^1.2.2
+    dart_neo4j: ^1.2.2
+    dart_neo4j_ogm: ^1.2.2
+    dart_neo4j_ogm_generator: ^1.2.2
+    dart_packstream: ^1.2.2
 
     analyzer: ^8.0.0
     build: ^4.0.0

--- a/packages/dart_bolt/CHANGELOG.md
+++ b/packages/dart_bolt/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 1.2.2
+
+- Version bump for consistency with dart_neo4j ecosystem
+
 ## 1.2.1
+
 - Version bump for consistency with dart_neo4j ecosystem
 
 ## 1.2.0

--- a/packages/dart_bolt/CHANGELOG.md
+++ b/packages/dart_bolt/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.2
 
-- Version bump for consistency with dart_neo4j ecosystem
+- Fix byte-ordering in protocol version numbers. Wrap the raw version number using an extension type to provide easier handling of version numbers.
+- Added optional `forcedVersions` arguments to enable forcing a connection into using a specific version (vs. the built-in versions officially supported by the driver). This enables integration testing, e.g. forcing a connection to use version 4.4 with a Neo4j 2025 instance.
 
 ## 1.2.1
 

--- a/packages/dart_bolt/lib/src/connection/bolt_protocol.dart
+++ b/packages/dart_bolt/lib/src/connection/bolt_protocol.dart
@@ -3,8 +3,8 @@ import 'dart:typed_data';
 
 import 'package:dart_bolt/src/connection/bolt_socket.dart';
 import 'package:dart_bolt/src/connection/connection_exceptions.dart';
-import 'package:dart_packstream/dart_packstream.dart';
 import 'package:dart_bolt/src/messages/bolt_message.dart';
+import 'package:dart_packstream/dart_packstream.dart';
 
 /// Handles Bolt protocol operations including handshake, chunking, and message parsing.
 class BoltProtocol {
@@ -12,11 +12,11 @@ class BoltProtocol {
   static const int _maxChunkSize = 0xFFFF;
 
   /// Supported protocol versions in descending order of preference.
-  static const List<int> _supportedVersions = [
-    0x00000508, // Version 5.8
-    0x00000505, // Version 5.5
-    0x00000405, // Version 4.5
-    0x00000404, // Version 4.4
+  static const List<BoltVersion> _supportedVersions = [
+    BoltVersion(major: 5, minor: 8), // Version 5.8
+    BoltVersion(major: 5, minor: 5), // Version 5.5
+    BoltVersion(major: 4, minor: 5), // Version 4.5
+    BoltVersion(major: 4, minor: 4), // Version 4.4
   ];
 
   final BoltSocket _socket;
@@ -37,18 +37,20 @@ class BoltProtocol {
   /// Returns the agreed protocol version.
   /// Throws [ProtocolException] if version negotiation fails.
   /// Throws [ConnectionTimeoutException] if handshake times out.
-  Future<int> performHandshake() async {
+  Future<int> performHandshake([List<BoltVersion>? forcedVersions]) async {
     // Create handshake message
     final handshake = ByteData(20);
     handshake.setUint32(0, _magicPreamble, Endian.big);
 
+    final versions = forcedVersions ?? _supportedVersions;
+
     // Add supported versions
-    for (int i = 0; i < 4 && i < _supportedVersions.length; i++) {
-      handshake.setUint32(4 + (i * 4), _supportedVersions[i], Endian.big);
+    for (int i = 0; i < 4 && i < versions.length; i++) {
+      handshake.setUint32(4 + (i * 4), versions[i].rawVersion, Endian.big);
     }
 
     // Fill remaining slots with zeros if needed
-    for (int i = _supportedVersions.length; i < 4; i++) {
+    for (int i = versions.length; i < 4; i++) {
       handshake.setUint32(4 + (i * 4), 0, Endian.big);
     }
 
@@ -67,29 +69,30 @@ class BoltProtocol {
       }
     });
 
-    _agreedVersion = await versionCompleter.future.timeout(
-      const Duration(seconds: 10),
+    final timeout = const Duration(seconds: 10);
+    final version = _agreedVersion = await versionCompleter.future.timeout(
+      timeout,
       onTimeout: () => throw ConnectionTimeoutException(
         'Handshake timeout: server did not respond to version negotiation',
-        const Duration(seconds: 10),
+        timeout,
       ),
     );
 
-    if (_agreedVersion == 0) {
+    if (version == 0) {
       throw ProtocolException(
         'Server does not support any of the requested protocol versions',
-        _agreedVersion,
+        version,
       );
     }
 
-    if (!_supportedVersions.contains(_agreedVersion)) {
+    if (!versions.contains(BoltVersion.raw(version))) {
       throw ProtocolException(
         'Server negotiated an unexpected protocol version',
-        _agreedVersion,
+        version,
       );
     }
 
-    return _agreedVersion!;
+    return version;
   }
 
   /// Sends a Bolt message by chunking it according to the protocol.
@@ -224,4 +227,27 @@ class BoltProtocol {
     _partialData = null;
     _currentMessageData.clear();
   }
+}
+
+/// Bolt version based on big-endian representation
+extension type const BoltVersion.raw(int rawVersion) {
+  const BoltVersion({required int major, required int minor})
+    : this.raw((minor << 8) | major);
+
+  int get major => rawVersion & 0xFF;
+  int get minor => (rawVersion & 0xFF00) >> 8;
+
+  bool operator <(BoltVersion other) =>
+      (major < other.major) || (major == other.major && minor < other.minor);
+
+  bool operator <=(BoltVersion other) =>
+      (major < other.major) || (major == other.major && minor <= other.minor);
+
+  bool operator >(BoltVersion other) =>
+      (major > other.major) || (major == other.major && minor > other.minor);
+
+  bool operator >=(BoltVersion other) =>
+      (major > other.major) || (major == other.major && minor >= other.minor);
+
+  static const v5_1 = BoltVersion(major: 5, minor: 1);
 }

--- a/packages/dart_bolt/pubspec.yaml
+++ b/packages/dart_bolt/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_bolt
 description: A Dart library for Bolt protocol implementation.
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_bolt
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  dart_packstream: ^1.2.1 # Configured via catalog
+  dart_packstream: ^1.2.2 # Configured via catalog
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/dart_neo4j/CHANGELOG.md
+++ b/packages/dart_neo4j/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.2
+
+#### Support new authentication flow with Neo4j version >= 5.1
+
+- Starting from 5.1, the `HELLO` message does not support sending authentication details.
+- For more information, see https://neo4j.com/docs/bolt/current/bolt/server-state/#_version_5_1. 
+
 ## 1.2.1
 
 #### Allow for running long running queries (#4)

--- a/packages/dart_neo4j/CHANGELOG.md
+++ b/packages/dart_neo4j/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 1.2.2
 
-#### Support new authentication flow with Neo4j version >= 5.1
+#### Support old authentication flow with Neo4j version < 5.1
 
-- Starting from 5.1, the `HELLO` message does not support sending authentication details.
-- For more information, see https://neo4j.com/docs/bolt/current/bolt/server-state/#_version_5_1. 
+- Refactor authentication flow to support authentication with a single `HELLO` message (protocol versions < 5.1), and keep the existing `HELLO`/`LOGON` flow for newer versions. For more information, see https://neo4j.com/docs/bolt/current/bolt/server-state/#_version_5_1.
+- Added optional `forcedVersions` arguments to enable forcing a connection into using a specific version (vs. the built-in versions officially supported by the driver -- see `bolt_protocol.dart` in `package:dart_bolt`). This enables integration testing, e.g. forcing a connection to use version 4.4 with a Neo4j 2025 instance.
+- Added connectivity tests for protocol versions 4.4, 5.0 and 5.1.
 
 ## 1.2.1
 

--- a/packages/dart_neo4j/lib/dart_neo4j_version.dart
+++ b/packages/dart_neo4j/lib/dart_neo4j_version.dart
@@ -1,0 +1,1 @@
+const version = '1.2.2';

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -113,7 +113,7 @@ class BoltConnection {
     final helloMessage = _createHelloMessage(includeAuth ? _auth : null);
     final helloResponse = await _sendMessage(helloMessage);
 
-    if (helloResponse is BoltSuccessMessage && includeAuth) {
+    if (helloResponse is BoltSuccessMessage) {
       if (includeAuth) {
         // Authentication successful - server is now in READY state
         _serverState = BoltServerState.ready;

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:dart_bolt/dart_bolt.dart';
+import 'package:dart_neo4j/dart_neo4j_version.dart';
 import 'package:dart_neo4j/src/auth/auth_token.dart';
 import 'package:dart_neo4j/src/auth/basic_auth.dart';
 import 'package:dart_neo4j/src/driver/uri_parser.dart';
@@ -64,7 +65,7 @@ class BoltConnection {
   /// Establishes and initializes the Bolt connection.
   ///
   /// This performs the full Bolt handshake and authentication.
-  Future<void> connect() async {
+  Future<void> connect([List<BoltVersion>? forcedVersions]) async {
     if (_serverState != BoltServerState.disconnected &&
         _serverState != BoltServerState.defunct) {
       throw ConnectionException(
@@ -82,7 +83,7 @@ class BoltConnection {
       await _socket.connect();
 
       // Perform Bolt handshake (before setting up message processing)
-      await _protocol.performHandshake();
+      await _protocol.performHandshake(forcedVersions);
 
       // Set up data processing for chunked messages
       _dataSubscription = _socket.dataStream.listen(
@@ -102,34 +103,93 @@ class BoltConnection {
     }
   }
 
+  Future<void> _authenticate() {
+    final version = BoltVersion.raw(protocolVersion!);
+    return (version < BoltVersion.v5_1)
+        ? _authenticateWithoutLogon()
+        : _authenticateWithLogon();
+  }
+
+  /// Authenticates with the Neo4j server using HELLO flow.
+  Future<void> _authenticateWithoutLogon() async {
+    // Step 1: Send HELLO message (with authentication for older protocols)
+    _serverState = BoltServerState.authentication;
+
+    final helloMessage = switch (_auth) {
+      BasicAuth auth => BoltMessageFactory.helloWithAuth(
+        userAgent: 'dart_neo4j/$version',
+        username: auth.username,
+        password: auth.password,
+        boltAgent: {
+          'product': 'dart_neo4j/$version',
+          'platform': 'Dart',
+          'language': 'Dart',
+        },
+      ),
+      NoAuth() => BoltMessageFactory.hello(
+        userAgent: 'dart_neo4j/$version',
+        boltAgent: {
+          'product': 'dart_neo4j/$version',
+          'platform': 'Dart',
+          'language': 'Dart',
+        },
+      ),
+      _ => throw ProtocolException(
+        'Unsupported AuthToken ${_auth.runtimeType}',
+      ),
+    };
+
+    final helloResponse = await _sendMessage(helloMessage);
+
+    if (helloResponse is! BoltSuccessMessage) {
+      if (helloResponse is BoltFailureMessage) {
+        _serverState = BoltServerState.failed;
+        final metadata =
+            helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+        final code = metadata['code'] as String? ?? 'unknown';
+        final message = metadata['message'] as String? ?? 'HELLO failed';
+        throw DatabaseException(message, code);
+      } else {
+        throw ProtocolException(
+          'Unexpected response to HELLO: ${helloResponse.runtimeType}',
+        );
+      }
+    }
+
+    // Authentication successful - server is now in READY state
+    _serverState = BoltServerState.ready;
+    return;
+  }
+
   /// Authenticates with the Neo4j server using HELLO/LOGON flow.
-  Future<void> _authenticate() async {
+  Future<void> _authenticateWithLogon() async {
     // Step 1: Send HELLO message (without authentication for newer protocols)
     _serverState = BoltServerState.authentication;
 
-    // see https://neo4j.com/docs/bolt/current/bolt/server-state/#_version_5_1
-    final includeAuth = (_protocol.agreedVersion! < 0x00000501);
+    final helloMessage = BoltMessageFactory.hello(
+      userAgent: 'dart_neo4j/$version',
+      boltAgent: {
+        'product': 'dart_neo4j/$version',
+        'platform': 'Dart',
+        'language': 'Dart',
+      },
+    );
 
-    final helloMessage = _createHelloMessage(includeAuth ? _auth : null);
     final helloResponse = await _sendMessage(helloMessage);
 
-    if (helloResponse is BoltSuccessMessage) {
-      if (includeAuth) {
-        // Authentication successful - server is now in READY state
-        _serverState = BoltServerState.ready;
-        return;
+    if (helloResponse is! BoltSuccessMessage) {
+      if (helloResponse is BoltFailureMessage) {
+        _serverState = BoltServerState.failed;
+        final metadata =
+            helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+        final code = metadata['code'] as String? ?? 'unknown';
+        final message = metadata['message'] as String? ?? 'HELLO failed';
+        throw DatabaseException(message, code);
+      } else {
+        throw ProtocolException(
+          'Unexpected response to HELLO: ${helloResponse.runtimeType}',
+        );
       }
-    } else if (helloResponse is BoltFailureMessage) {
-      _serverState = BoltServerState.failed;
-      final metadata =
-          helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
-      final code = metadata['code'] as String? ?? 'unknown';
-      final message = metadata['message'] as String? ?? 'HELLO failed';
-      throw DatabaseException(message, code);
-    } else {
-      throw ProtocolException(
-        'Unexpected response to HELLO: ${helloResponse.runtimeType}',
-      );
     }
 
     // Step 2: Send LOGON message with authentication details
@@ -155,35 +215,6 @@ class BoltConnection {
     } else {
       throw ProtocolException(
         'Unexpected response to LOGON: ${logonResponse.runtimeType}',
-      );
-    }
-  }
-
-  /// Creates a HELLO message based on the agreedVersion.
-  BoltHelloMessage _createHelloMessage(AuthToken? auth) {
-    if (auth == null || auth is NoAuth) {
-      return BoltMessageFactory.hello(
-        userAgent: 'dart_neo4j/1.0.0',
-        boltAgent: {
-          'product': 'dart_neo4j/1.0.0',
-          'platform': 'Dart',
-          'language': 'Dart',
-        },
-      );
-    } else if (auth is BasicAuth) {
-      return BoltMessageFactory.helloWithAuth(
-        userAgent: 'dart_neo4j/1.0.0',
-        boltAgent: {
-          'product': 'dart_neo4j/1.0.0',
-          'platform': 'Dart',
-          'language': 'Dart',
-        },
-        username: auth.username,
-        password: auth.password,
-      );
-    } else {
-      throw ClientException(
-        'Only Basic authentication is supported with legacy protocols (< 5.1)',
       );
     }
   }
@@ -652,7 +683,8 @@ class BoltConnection {
   }
 
   @override
-  String toString() {
-    return 'BoltConnection{uri: ${_uri.host}:${_uri.port}, serverState: $_serverState, version: $protocolVersion}';
-  }
+  String toString() =>
+      'BoltConnection{uri: ${_uri.host}:${_uri.port},'
+      ' serverState: $_serverState,'
+      ' version: ${protocolVersion?.toRadixString(16)}}';
 }

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -145,10 +145,14 @@ class BoltConnection {
       if (helloResponse is BoltFailureMessage) {
         _serverState = BoltServerState.failed;
         final metadata =
-            helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            helloResponse.metadata.dartValue as Map<String, dynamic>? ??
+            const {};
         final code = metadata['code'] as String? ?? 'unknown';
-        final message = metadata['message'] as String? ?? 'HELLO failed';
-        throw DatabaseException(message, code);
+        final message =
+            metadata['message'] as String? ?? 'Authentication failed';
+        throw _isAuthError(code, message)
+            ? AuthenticationException(message)
+            : DatabaseException(message, code);
       } else {
         throw ProtocolException(
           'Unexpected response to HELLO: ${helloResponse.runtimeType}',
@@ -181,7 +185,8 @@ class BoltConnection {
       if (helloResponse is BoltFailureMessage) {
         _serverState = BoltServerState.failed;
         final metadata =
-            helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            helloResponse.metadata.dartValue as Map<String, dynamic>? ??
+            const {};
         final code = metadata['code'] as String? ?? 'unknown';
         final message = metadata['message'] as String? ?? 'HELLO failed';
         throw DatabaseException(message, code);
@@ -203,20 +208,25 @@ class BoltConnection {
     } else if (logonResponse is BoltFailureMessage) {
       _serverState = BoltServerState.failed;
       final metadata =
-          logonResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+          logonResponse.metadata.dartValue as Map<String, dynamic>? ?? const {};
       final code = metadata['code'] as String? ?? 'unknown';
       final message = metadata['message'] as String? ?? 'Authentication failed';
-
-      if (code.startsWith('Neo.ClientError.Security.Unauthorized')) {
-        throw AuthenticationException(message);
-      } else {
-        throw DatabaseException(message, code);
-      }
+      throw _isAuthError(code, message)
+          ? AuthenticationException(message)
+          : DatabaseException(message, code);
     } else {
       throw ProtocolException(
         'Unexpected response to LOGON: ${logonResponse.runtimeType}',
       );
     }
+  }
+
+  static bool _isAuthError(String code, String message) {
+    code = code.toLowerCase();
+    if (code.startsWith('neo.clienterror.security.unauthorized')) return true;
+    message = message.toLowerCase();
+    return message.contains('unauthorized') ||
+        message.contains('authentication failure');
   }
 
   /// Creates a LOGON message based on the authentication token type.
@@ -256,9 +266,9 @@ class BoltConnection {
 
     try {
       final beginMessage = BoltMessageFactory.begin(
-        bookmarks: bookmarks ?? [],
+        bookmarks: bookmarks ?? const [],
         txTimeout: txTimeout,
-        txMetadata: txMetadata ?? {},
+        txMetadata: txMetadata ?? const {},
         mode: mode,
         db: db,
       );
@@ -272,7 +282,8 @@ class BoltConnection {
         // BEGIN failed - server transitions to FAILED state
         _serverState = BoltServerState.failed;
         final metadata =
-            beginResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            beginResponse.metadata.dartValue as Map<String, dynamic>? ??
+            const {};
         final code = metadata['code'] as String? ?? 'unknown';
         final message =
             metadata['message'] as String? ?? 'Transaction begin failed';
@@ -306,7 +317,8 @@ class BoltConnection {
         // COMMIT failed - server transitions to FAILED state
         _serverState = BoltServerState.failed;
         final metadata =
-            commitResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            commitResponse.metadata.dartValue as Map<String, dynamic>? ??
+            const {};
         final code = metadata['code'] as String? ?? 'unknown';
         final message =
             metadata['message'] as String? ?? 'Transaction commit failed';
@@ -340,7 +352,8 @@ class BoltConnection {
         // ROLLBACK failed - server transitions to FAILED state
         _serverState = BoltServerState.failed;
         final metadata =
-            rollbackResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            rollbackResponse.metadata.dartValue as Map<String, dynamic>? ??
+            const {};
         final code = metadata['code'] as String? ?? 'unknown';
         final message =
             metadata['message'] as String? ?? 'Transaction rollback failed';
@@ -402,14 +415,15 @@ class BoltConnection {
           _serverState = BoltServerState.streaming;
         }
         final metadata =
-            runResponse.metadata?.dartValue as Map<String, dynamic>? ?? {};
-        final fieldsData = metadata['fields'] as List<dynamic>? ?? [];
+            runResponse.metadata?.dartValue as Map<String, dynamic>? ??
+            const {};
+        final fieldsData = metadata['fields'] as List<dynamic>? ?? const [];
         keys = fieldsData.cast<String>();
       } else if (runResponse is BoltFailureMessage) {
         // RUN failed - server transitions to FAILED state
         _serverState = BoltServerState.failed;
         final metadata =
-            runResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            runResponse.metadata.dartValue as Map<String, dynamic>? ?? const {};
         final code = metadata['code'] as String? ?? 'unknown';
         final message =
             metadata['message'] as String? ?? 'Query execution failed';
@@ -447,7 +461,8 @@ class BoltConnection {
             // PULL failed - server transitions to FAILED state
             _serverState = BoltServerState.failed;
             final metadata =
-                pullResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+                pullResponse.metadata.dartValue as Map<String, dynamic>? ??
+                const {};
             final code = metadata['code'] as String? ?? 'unknown';
             final message =
                 metadata['message'] as String? ?? 'Result fetch failed';
@@ -639,7 +654,8 @@ class BoltConnection {
         // RESET failed - connection is likely defunct
         _serverState = BoltServerState.defunct;
         final metadata =
-            resetResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+            resetResponse.metadata.dartValue as Map<String, dynamic>? ??
+            const {};
         final code = metadata['code'] as String? ?? 'unknown';
         final message = metadata['message'] as String? ?? 'Reset failed';
         throw ConnectionException(
@@ -662,7 +678,8 @@ class BoltConnection {
     String query,
     Map<String, dynamic> parameters,
   ) {
-    final metadata = message.metadata?.dartValue as Map<String, dynamic>? ?? {};
+    final metadata =
+        message.metadata?.dartValue as Map<String, dynamic>? ?? const {};
     return ResultSummary.fromMetadata(query, parameters, metadata);
   }
 

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -226,7 +226,7 @@ class BoltConnection {
     if (code.startsWith('neo.clienterror.security.unauthorized')) return true;
     message = message.toLowerCase();
     return message.contains('unauthorized') ||
-        message.contains('authentication failure');
+        message.contains('authentication fail');
   }
 
   /// Creates a LOGON message based on the authentication token type.

--- a/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
+++ b/packages/dart_neo4j/lib/src/connection/bolt_connection.dart
@@ -107,30 +107,29 @@ class BoltConnection {
     // Step 1: Send HELLO message (without authentication for newer protocols)
     _serverState = BoltServerState.authentication;
 
-    final helloMessage = BoltMessageFactory.hello(
-      userAgent: 'dart_neo4j/1.0.0',
-      boltAgent: {
-        'product': 'dart_neo4j/1.0.0',
-        'platform': 'Dart',
-        'language': 'Dart',
-      },
-    );
+    // see https://neo4j.com/docs/bolt/current/bolt/server-state/#_version_5_1
+    final includeAuth = (_protocol.agreedVersion! < 0x00000501);
 
+    final helloMessage = _createHelloMessage(includeAuth ? _auth : null);
     final helloResponse = await _sendMessage(helloMessage);
 
-    if (helloResponse is! BoltSuccessMessage) {
-      if (helloResponse is BoltFailureMessage) {
-        _serverState = BoltServerState.failed;
-        final metadata =
-            helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
-        final code = metadata['code'] as String? ?? 'unknown';
-        final message = metadata['message'] as String? ?? 'HELLO failed';
-        throw DatabaseException(message, code);
-      } else {
-        throw ProtocolException(
-          'Unexpected response to HELLO: ${helloResponse.runtimeType}',
-        );
+    if (helloResponse is BoltSuccessMessage && includeAuth) {
+      if (includeAuth) {
+        // Authentication successful - server is now in READY state
+        _serverState = BoltServerState.ready;
+        return;
       }
+    } else if (helloResponse is BoltFailureMessage) {
+      _serverState = BoltServerState.failed;
+      final metadata =
+          helloResponse.metadata.dartValue as Map<String, dynamic>? ?? {};
+      final code = metadata['code'] as String? ?? 'unknown';
+      final message = metadata['message'] as String? ?? 'HELLO failed';
+      throw DatabaseException(message, code);
+    } else {
+      throw ProtocolException(
+        'Unexpected response to HELLO: ${helloResponse.runtimeType}',
+      );
     }
 
     // Step 2: Send LOGON message with authentication details
@@ -156,6 +155,35 @@ class BoltConnection {
     } else {
       throw ProtocolException(
         'Unexpected response to LOGON: ${logonResponse.runtimeType}',
+      );
+    }
+  }
+
+  /// Creates a HELLO message based on the agreedVersion.
+  BoltHelloMessage _createHelloMessage(AuthToken? auth) {
+    if (auth == null || auth is NoAuth) {
+      return BoltMessageFactory.hello(
+        userAgent: 'dart_neo4j/1.0.0',
+        boltAgent: {
+          'product': 'dart_neo4j/1.0.0',
+          'platform': 'Dart',
+          'language': 'Dart',
+        },
+      );
+    } else if (auth is BasicAuth) {
+      return BoltMessageFactory.helloWithAuth(
+        userAgent: 'dart_neo4j/1.0.0',
+        boltAgent: {
+          'product': 'dart_neo4j/1.0.0',
+          'platform': 'Dart',
+          'language': 'Dart',
+        },
+        username: auth.username,
+        password: auth.password,
+      );
+    } else {
+      throw ClientException(
+        'Only Basic authentication is supported with legacy protocols (< 5.1)',
       );
     }
   }

--- a/packages/dart_neo4j/lib/src/connection/connection_pool.dart
+++ b/packages/dart_neo4j/lib/src/connection/connection_pool.dart
@@ -306,7 +306,7 @@ class ConnectionPool {
       final pooledConnection = PooledConnection(boltConnection);
       _allConnections.add(pooledConnection);
       return pooledConnection;
-    } catch (e) {
+    } catch (_) {
       await boltConnection.close();
       rethrow;
     }

--- a/packages/dart_neo4j/lib/src/connection/connection_pool.dart
+++ b/packages/dart_neo4j/lib/src/connection/connection_pool.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:io';
 
 import 'package:dart_bolt/dart_bolt.dart' as bolt;
+import 'package:dart_bolt/dart_bolt.dart' show BoltVersion;
 import 'package:dart_neo4j/src/auth/auth_token.dart';
 import 'package:dart_neo4j/src/connection/bolt_connection.dart';
 import 'package:dart_neo4j/src/driver/uri_parser.dart';
@@ -131,13 +132,13 @@ class ConnectionPool {
   ///
   /// Throws [ServiceUnavailableException] if the pool is closed.
   /// Throws [ConnectionTimeoutException] if no connection becomes available within the timeout.
-  Future<PooledConnection> acquire() async {
+  Future<PooledConnection> acquire([List<BoltVersion>? forcedVersions]) async {
     if (_closed) {
       throw const ServiceUnavailableException('Connection pool is closed');
     }
 
     // Try to get an available connection
-    PooledConnection? connection = _getAvailableConnection();
+    PooledConnection? connection = _getAvailableConnection(forcedVersions);
     if (connection != null) {
       connection.markInUse();
       return connection;
@@ -146,7 +147,7 @@ class ConnectionPool {
     // Try to create a new connection if under capacity
     if (_allConnections.length < _config.maxSize) {
       try {
-        connection = await _createConnection();
+        connection = await _createConnection(forcedVersions);
         connection.markInUse();
         return connection;
       } catch (e) {
@@ -240,36 +241,58 @@ class ConnectionPool {
   }
 
   /// Gets an available connection from the pool.
-  PooledConnection? _getAvailableConnection() {
-    while (_availableConnections.isNotEmpty) {
-      final connection = _availableConnections.removeFirst();
+  PooledConnection? _getAvailableConnection([
+    List<BoltVersion>? forcedVersions,
+  ]) {
+    final uneligible = <PooledConnection>[];
+    try {
+      while (_availableConnections.isNotEmpty) {
+        final connection = _availableConnections.removeFirst();
 
-      if (connection.connection.isClosed) {
-        _removeConnection(connection);
-        continue;
-      }
-
-      // Check if connection is in FAILED state and try to reset it
-      if (connection.connection.serverState == bolt.BoltServerState.failed) {
-        // Try to reset the connection to make it usable again
-        try {
-          // We can't await here, so we'll remove failed connections and let a new one be created
-          _removeConnection(connection);
-          continue;
-        } catch (e) {
-          // If reset fails, remove the connection
+        if (connection.connection.isClosed) {
           _removeConnection(connection);
           continue;
         }
-      }
 
-      return connection;
+        // Check if connection is in FAILED state and try to reset it
+        if (connection.connection.serverState == bolt.BoltServerState.failed) {
+          // Try to reset the connection to make it usable again
+          try {
+            // We can't await here, so we'll remove failed connections and let a new one be created
+            _removeConnection(connection);
+            continue;
+          } catch (e) {
+            // If reset fails, remove the connection
+            _removeConnection(connection);
+            continue;
+          }
+        }
+
+        // check forced version match
+        if (forcedVersions == null || forcedVersions.isEmpty) {
+          return connection;
+        } else {
+          final version = BoltVersion.raw(
+            connection.connection.protocolVersion ?? 0,
+          );
+          if (forcedVersions.contains(version)) {
+            return connection;
+          } else {
+            uneligible.add(connection);
+          }
+        }
+      }
+      return null;
+    } finally {
+      // return uneligible connections to the pool
+      _availableConnections.addAll(uneligible);
     }
-    return null;
   }
 
   /// Creates a new connection.
-  Future<PooledConnection> _createConnection() async {
+  Future<PooledConnection> _createConnection([
+    List<BoltVersion>? forcedVersions,
+  ]) async {
     final boltConnection = BoltConnection(
       _uri,
       _auth,
@@ -279,7 +302,7 @@ class ConnectionPool {
     );
 
     try {
-      await boltConnection.connect();
+      await boltConnection.connect(forcedVersions);
       final pooledConnection = PooledConnection(boltConnection);
       _allConnections.add(pooledConnection);
       return pooledConnection;

--- a/packages/dart_neo4j/lib/src/driver/neo4j_driver.dart
+++ b/packages/dart_neo4j/lib/src/driver/neo4j_driver.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:dart_bolt/dart_bolt.dart' show BoltVersion;
 import 'package:dart_neo4j/src/auth/auth_token.dart';
 import 'package:dart_neo4j/src/connection/connection_pool.dart';
 import 'package:dart_neo4j/src/driver/uri_parser.dart';
@@ -102,7 +103,7 @@ abstract class Neo4jDriver {
   ///
   /// Throws [ServiceUnavailableException] if the server is not available.
   /// Throws [AuthenticationException] if authentication fails.
-  Future<void> verifyConnectivity();
+  Future<void> verifyConnectivity([List<BoltVersion>? forcedVersions]);
 
   /// Closes this driver and releases all associated resources.
   ///
@@ -153,14 +154,14 @@ class _Neo4jDriverImpl implements Neo4jDriver {
   }
 
   @override
-  Future<void> verifyConnectivity() async {
+  Future<void> verifyConnectivity([List<BoltVersion>? forcedVersions]) async {
     if (_isClosed) {
       throw const ServiceUnavailableException('Driver has been closed');
     }
 
     // Attempt to acquire and immediately release a connection
     try {
-      final connection = await _connectionPool.acquire();
+      final connection = await _connectionPool.acquire(forcedVersions);
       _connectionPool.release(connection);
     } catch (e) {
       // Let specific exceptions pass through, wrap others in ServiceUnavailableException

--- a/packages/dart_neo4j/pubspec.yaml
+++ b/packages/dart_neo4j/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j
 description: A comprehensive Neo4j driver for Dart supporting both bolt:// and neo4j:// URI schemes with type-safe result access.
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j
 
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  dart_bolt: ^1.2.1 # Configured via catalog
+  dart_bolt: ^1.2.2 # Configured via catalog
 
 dev_dependencies:
   lints: ^5.0.0

--- a/packages/dart_neo4j/test/integration/basic/driver_test.dart
+++ b/packages/dart_neo4j/test/integration/basic/driver_test.dart
@@ -1,3 +1,4 @@
+import 'package:dart_bolt/dart_bolt.dart' show BoltVersion;
 import 'package:dart_neo4j/dart_neo4j.dart';
 import 'package:dart_neo4j/src/driver/uri_parser.dart';
 import 'package:test/test.dart';
@@ -69,6 +70,51 @@ void main() {
 
         await expectLater(driver.verifyConnectivity(), completes);
       });
+
+      test(
+        'verifies connectivity successfully (force version to 4.4)',
+        () async {
+          driver = Neo4jDriver.create(
+            TestConfig.boltUri,
+            auth: TestConfig.auth,
+          );
+
+          await expectLater(
+            driver.verifyConnectivity([BoltVersion(major: 4, minor: 4)]),
+            completes,
+          );
+        },
+      );
+
+      test(
+        'verifies connectivity successfully (force version to 5.0)',
+        () async {
+          driver = Neo4jDriver.create(
+            TestConfig.boltUri,
+            auth: TestConfig.auth,
+          );
+
+          await expectLater(
+            driver.verifyConnectivity([BoltVersion(major: 5, minor: 0)]),
+            completes,
+          );
+        },
+      );
+
+      test(
+        'verifies connectivity successfully (force version to 5.1)',
+        () async {
+          driver = Neo4jDriver.create(
+            TestConfig.boltUri,
+            auth: TestConfig.auth,
+          );
+
+          await expectLater(
+            driver.verifyConnectivity([BoltVersion.v5_1]),
+            completes,
+          );
+        },
+      );
 
       test('throws on connectivity failure with wrong port', () async {
         const config = DriverConfig(

--- a/packages/dart_neo4j_ogm/CHANGELOG.md
+++ b/packages/dart_neo4j_ogm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Version bump for consistency with dart_neo4j ecosystem
+
 ## 1.2.1
 
 - Version bump for consistency with dart_neo4j ecosystem

--- a/packages/dart_neo4j_ogm/pubspec.yaml
+++ b/packages/dart_neo4j_ogm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j_ogm
 description: Annotations for Neo4j Object-Graph Mapping (OGM) code generation in Dart.
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j_ogm
 

--- a/packages/dart_neo4j_ogm_generator/CHANGELOG.md
+++ b/packages/dart_neo4j_ogm_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Version bump for consistency with dart_neo4j ecosystem
+
 ## 1.2.1
 
 - Version bump for consistency with dart_neo4j ecosystem

--- a/packages/dart_neo4j_ogm_generator/pubspec.yaml
+++ b/packages/dart_neo4j_ogm_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_neo4j_ogm_generator
 description: Code generator for dart_neo4j_ogm annotations. Generates Cypher query construction methods for Neo4j OGM.
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_neo4j_ogm_generator
 
@@ -19,7 +19,7 @@ dependencies:
   analyzer: ^8.0.0 # Configured via catalog
 
   # Annotation package
-  dart_neo4j_ogm: ^1.2.1 # Configured via catalog
+  dart_neo4j_ogm: ^1.2.2 # Configured via catalog
 
 dev_dependencies:
   # Testing
@@ -27,8 +27,8 @@ dev_dependencies:
   build_test: ^3.0.0
 
   # Neo4j driver and bolt for integration tests
-  dart_neo4j: ^1.2.1 # Configured via catalog
-  dart_bolt: ^1.2.1 # Configured via catalog
+  dart_neo4j: ^1.2.2 # Configured via catalog
+  dart_bolt: ^1.2.2 # Configured via catalog
 
   # Freezed for testing compatibility
   freezed: ^3.2.0

--- a/packages/dart_packstream/CHANGELOG.md
+++ b/packages/dart_packstream/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Version bump for consistency with dart_neo4j ecosystem
+
 ## 1.2.1
 
 - Version bump for consistency with dart_neo4j ecosystem

--- a/packages/dart_packstream/pubspec.yaml
+++ b/packages/dart_packstream/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_packstream
 description: A Dart library for serializing and deserializing data using the Packstream format.
-version: 1.2.1
+version: 1.2.2
 resolution: workspace
 repository: https://github.com/exaby73/dart_neo4j/tree/main/packages/dart_packstream
 


### PR DESCRIPTION
Auth flow for legacy drivers was not supported (although one of the HELLO message constructors accepts an AuthToken, but this constructor wasn't used). Fixing this actually revealed the versions in `neo4j_bolt` were wrong: 0x00000508 does not match version 5.8 but version 8.5 because of wrong byte order. Also, I'm not sure version 4.5 really exists: it was actually matched to negotiate version 5.4 (also due to wrong byte order).

I have fixed the versions supported out-of-the box by the driver, and added optional `forcedVersions` parameters to test version negotiation + associated unit tests. And restored support of legacy auth flow :-)